### PR TITLE
chore: add color-scheme dark meta tag

### DIFF
--- a/lib/siteMetadata.ts
+++ b/lib/siteMetadata.ts
@@ -11,6 +11,7 @@ const resolveMetadataBase = (appUrl?: string) => new URL(appUrl || DEFAULT_APP_U
 
 export const siteViewport: Viewport = {
   themeColor: '#020108',
+  colorScheme: 'dark',
 };
 
 export const buildSiteMetadata = (appUrl?: string): Metadata => ({


### PR DESCRIPTION
Adds `color-scheme` tag so browsers and extensions know the site is already dark and won't try to invert it.

Note:
- OG/Twitter images are resolving to `DEFAULT_APP_URL` on the production instance (xrdb.ibbylabs.dev), `NEXT_PUBLIC_APP_URL` env var appears to not be set in the deployment config.
- The README build instructions (`npm run build && npm run start`) are missing a step, Next.js standalone output requires manually copying `.next/static` and `public` into `.next/standalone/`. The Dockerfile already handles this explicitly, so I didn't want to add a postbuild script and make it redundant, leaving it to you to decide whether to document the manual steps or consolidate into a postbuild.