### PR TITLE
fix: anime ratings via self-managed ID mapping (replaces dead mapping service)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ All notable changes to XRDB are documented here.
 
 ### Fixed
 
+- Anime ratings (MyAnimeList, AniList, Kitsu) never rendered: the pipeline
+  passed IMDb/TMDB IDs straight to the anime providers, which only accept
+  their own ID space. A new anime ID mapper translates IDs via a disk-cached
+  [Fribb/anime-lists](https://github.com/Fribb/anime-lists) dataset with a
+  live API fallback — replacing the v2 approach that depended on a single
+  third-party mapping host (now offline with a DNS failure)
 - Fanart.tv rejected IMDb tt-IDs (every configurator render) and misrouted movie backdrops
 - Thumbnails now prefer backdrop artwork over center-cropped posters
 - Overlay metadata (age/genre/providers) backfills from TMDB when the artwork source lacks it

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -15,6 +15,7 @@ import (
 	"xrdb_rewrite/internal/config"
 	"xrdb_rewrite/internal/profile"
 	"xrdb_rewrite/internal/provider"
+	"xrdb_rewrite/internal/provider/animemap"
 	"xrdb_rewrite/internal/server"
 	"xrdb_rewrite/internal/settings"
 	"xrdb_rewrite/internal/ui"
@@ -90,10 +91,16 @@ func main() {
 	if cfg.IMDbDatasetDir != "" {
 		reg.Register(provider.NewIMDbDataset(cfg.IMDbDatasetDir))
 	}
-	// Anime providers — public APIs, no key required.
-	reg.Register(provider.NewMAL())
-	reg.Register(provider.NewAniList())
-	reg.Register(provider.NewKitsu())
+	// Anime providers — public APIs, no key required. Wrapped with the anime
+	// ID mapper so IMDb/TMDB render IDs resolve to MAL/AniList/Kitsu IDs.
+	animeMapper := animemap.New(animemap.Options{
+		CacheDir:    cfg.CacheDir,
+		DatasetURL:  cfg.AnimeMapURL,
+		FallbackURL: cfg.AnimeMapFallbackURL,
+	})
+	reg.Register(provider.NewAnimeMapped(provider.NewMAL(), animeMapper))
+	reg.Register(provider.NewAnimeMapped(provider.NewAniList(), animeMapper))
+	reg.Register(provider.NewAnimeMapped(provider.NewKitsu(), animeMapper))
 	// Cinemeta (Stremio) — public artwork/metadata, no key required.
 	reg.Register(provider.NewCinemeta())
 	var pipeline *compose.Pipeline

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -97,6 +97,7 @@ func main() {
 		CacheDir:    cfg.CacheDir,
 		DatasetURL:  cfg.AnimeMapURL,
 		FallbackURL: cfg.AnimeMapFallbackURL,
+		TTL:         cfg.AnimeMapRefresh,
 	})
 	reg.Register(provider.NewAnimeMapped(provider.NewMAL(), animeMapper))
 	reg.Register(provider.NewAnimeMapped(provider.NewAniList(), animeMapper))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	IMDbDatasetDir      string                   // directory for cached IMDb dataset file; empty = disabled
 	AnimeMapURL         string                   // override anime ID mapping dataset URL; empty = default
 	AnimeMapFallbackURL string                   // live anime mapping API base URL; "off" disables
+	AnimeMapRefresh     time.Duration            // anime mapping dataset refresh interval; 0 = default (7 days)
 	ProviderTTLs        map[string]time.Duration // per-provider TTL overrides; key = provider name
 	AdminKey            string                   // protects /api/admin/* routes
 	APIKey              string                   // if set, required on all render routes
@@ -74,6 +75,12 @@ func Load() Config {
 			cacheTTL = d
 		}
 	}
+	var animeMapRefresh time.Duration
+	if raw := os.Getenv("XRDB_ANIME_MAP_REFRESH_HOURS"); raw != "" {
+		if h, err := strconv.ParseFloat(raw, 64); err == nil && h > 0 {
+			animeMapRefresh = time.Duration(h * float64(time.Hour))
+		}
+	}
 	return Config{
 		Address:             addr,
 		Version:             version,
@@ -90,6 +97,7 @@ func Load() Config {
 		IMDbDatasetDir:      os.Getenv("XRDB_IMDB_DATASET_DIR"),
 		AnimeMapURL:         os.Getenv("XRDB_ANIME_MAP_URL"),
 		AnimeMapFallbackURL: os.Getenv("XRDB_ANIME_MAP_FALLBACK_URL"),
+		AnimeMapRefresh:     animeMapRefresh,
 		ProviderTTLs:        loadProviderTTLs(cacheTTL),
 		AdminKey:            os.Getenv("XRDB_ADMIN_KEY"),
 		APIKey:              os.Getenv("XRDB_API_KEY"),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,22 +8,24 @@ import (
 )
 
 type Config struct {
-	Address        string
-	Version        string
-	DBPath         string
-	CacheDir       string
-	CacheTTL       time.Duration
-	TMDBAPIKey     string
-	TMDBReadToken  string
-	MDBListAPIKey  string
-	OMDBAPIKey     string
-	FanartAPIKey   string
-	TraktClientID   string
-	SIMKLClientID   string
-	IMDbDatasetDir  string // directory for cached IMDb dataset file; empty = disabled
-	ProviderTTLs    map[string]time.Duration // per-provider TTL overrides; key = provider name
-	AdminKey        string // protects /api/admin/* routes
-	APIKey         string // if set, required on all render routes
+	Address             string
+	Version             string
+	DBPath              string
+	CacheDir            string
+	CacheTTL            time.Duration
+	TMDBAPIKey          string
+	TMDBReadToken       string
+	MDBListAPIKey       string
+	OMDBAPIKey          string
+	FanartAPIKey        string
+	TraktClientID       string
+	SIMKLClientID       string
+	IMDbDatasetDir      string                   // directory for cached IMDb dataset file; empty = disabled
+	AnimeMapURL         string                   // override anime ID mapping dataset URL; empty = default
+	AnimeMapFallbackURL string                   // live anime mapping API base URL; "off" disables
+	ProviderTTLs        map[string]time.Duration // per-provider TTL overrides; key = provider name
+	AdminKey            string                   // protects /api/admin/* routes
+	APIKey              string                   // if set, required on all render routes
 }
 
 // loadProviderTTLs builds the per-provider TTL map.
@@ -73,21 +75,23 @@ func Load() Config {
 		}
 	}
 	return Config{
-		Address:       addr,
-		Version:       version,
-		DBPath:        dbPath,
-		CacheDir:      cacheDir,
-		CacheTTL:      cacheTTL,
-		TMDBAPIKey:    os.Getenv("XRDB_TMDB_API_KEY"),
-		TMDBReadToken: os.Getenv("XRDB_TMDB_READ_TOKEN"),
-		MDBListAPIKey: os.Getenv("XRDB_MDBLIST_API_KEY"),
-		OMDBAPIKey:    os.Getenv("XRDB_OMDB_API_KEY"),
-		FanartAPIKey:  os.Getenv("XRDB_FANART_API_KEY"),
-		TraktClientID:  os.Getenv("XRDB_TRAKT_CLIENT_ID"),
-		SIMKLClientID:  os.Getenv("XRDB_SIMKL_CLIENT_ID"),
-		IMDbDatasetDir: os.Getenv("XRDB_IMDB_DATASET_DIR"),
-		ProviderTTLs:   loadProviderTTLs(cacheTTL),
-		AdminKey:       os.Getenv("XRDB_ADMIN_KEY"),
-		APIKey:        os.Getenv("XRDB_API_KEY"),
+		Address:             addr,
+		Version:             version,
+		DBPath:              dbPath,
+		CacheDir:            cacheDir,
+		CacheTTL:            cacheTTL,
+		TMDBAPIKey:          os.Getenv("XRDB_TMDB_API_KEY"),
+		TMDBReadToken:       os.Getenv("XRDB_TMDB_READ_TOKEN"),
+		MDBListAPIKey:       os.Getenv("XRDB_MDBLIST_API_KEY"),
+		OMDBAPIKey:          os.Getenv("XRDB_OMDB_API_KEY"),
+		FanartAPIKey:        os.Getenv("XRDB_FANART_API_KEY"),
+		TraktClientID:       os.Getenv("XRDB_TRAKT_CLIENT_ID"),
+		SIMKLClientID:       os.Getenv("XRDB_SIMKL_CLIENT_ID"),
+		IMDbDatasetDir:      os.Getenv("XRDB_IMDB_DATASET_DIR"),
+		AnimeMapURL:         os.Getenv("XRDB_ANIME_MAP_URL"),
+		AnimeMapFallbackURL: os.Getenv("XRDB_ANIME_MAP_FALLBACK_URL"),
+		ProviderTTLs:        loadProviderTTLs(cacheTTL),
+		AdminKey:            os.Getenv("XRDB_ADMIN_KEY"),
+		APIKey:              os.Getenv("XRDB_API_KEY"),
 	}
 }

--- a/internal/provider/anilist.go
+++ b/internal/provider/anilist.go
@@ -18,12 +18,14 @@ const anilistGraphQLURL = "https://graphql.anilist.co"
 // IDs must be prefixed with "al:" e.g. "al:21".
 type AniList struct {
 	httpClient *http.Client
+	baseURL    string // overridable for tests; defaults to anilistGraphQLURL
 }
 
 // NewAniList creates an AniList provider. No API key is required.
 func NewAniList() *AniList {
 	return &AniList{
 		httpClient: &http.Client{Timeout: 10 * time.Second},
+		baseURL:    anilistGraphQLURL,
 	}
 }
 
@@ -65,7 +67,11 @@ func (a *AniList) Fetch(ctx context.Context, mediaType, id string) (*MediaMeta, 
 		return nil, fmt.Errorf("anilist: build payload: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, anilistGraphQLURL,
+	base := a.baseURL
+	if base == "" {
+		base = anilistGraphQLURL
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base,
 		bytes.NewReader(bodyBytes))
 	if err != nil {
 		return nil, fmt.Errorf("anilist: build request: %w", err)

--- a/internal/provider/animemap/animemap.go
+++ b/internal/provider/animemap/animemap.go
@@ -1,0 +1,499 @@
+// Package animemap resolves IMDb and TMDB identifiers to anime-service IDs
+// (MyAnimeList, AniList, Kitsu).
+//
+// The primary source is the community-maintained Fribb/anime-lists dataset,
+// downloaded once and cached on disk so lookups are local and survive upstream
+// outages. Entries missing from the dataset fall back to a live mapping API
+// (arm.haglund.dev by default) with per-ID caching, including negative results.
+package animemap
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// IDs holds the per-service anime identifiers for one title. A zero value
+// means the service has no known ID for the title.
+type IDs struct {
+	MAL     int
+	AniList int
+	Kitsu   int
+}
+
+func (ids IDs) empty() bool { return ids.MAL == 0 && ids.AniList == 0 && ids.Kitsu == 0 }
+
+const (
+	// DefaultDatasetURL is the Fribb/anime-lists "mini" list (~6 MB), which
+	// carries every ID XRDB needs (mal/anilist/kitsu/imdb/themoviedb).
+	DefaultDatasetURL = "https://raw.githubusercontent.com/Fribb/anime-lists/master/anime-list-mini.json"
+	// DefaultDatasetMirrorURL is tried when the primary host is unreachable.
+	DefaultDatasetMirrorURL = "https://cdn.jsdelivr.net/gh/Fribb/anime-lists@master/anime-list-mini.json"
+	// DefaultFallbackURL is the live per-ID mapping API used for titles the
+	// dataset doesn't cover yet. Set to "off" in Options to disable.
+	DefaultFallbackURL = "https://arm.haglund.dev/api/v2"
+
+	datasetFileName    = "anime-map.json"
+	maxDatasetBytes    = 64 * 1024 * 1024
+	downloadTimeout    = 60 * time.Second
+	retryBackoff       = 5 * time.Minute
+	fallbackTimeout    = 8 * time.Second
+	fallbackCacheTTL   = 24 * time.Hour
+	fallbackCacheLimit = 10000
+)
+
+// Options configures a Mapper.
+type Options struct {
+	CacheDir    string        // directory for the cached dataset file (required)
+	DatasetURL  string        // override dataset URL (default Fribb anime-lists)
+	MirrorURL   string        // override mirror URL
+	FallbackURL string        // live mapping API base URL; "off" disables
+	TTL         time.Duration // dataset refresh interval (default 7 days)
+	HTTPClient  *http.Client  // override HTTP client (tests)
+}
+
+// Mapper resolves media IDs to anime-service IDs using a disk-cached dataset
+// with a live API fallback. Safe for concurrent use.
+type Mapper struct {
+	datasetURL  string
+	mirrorURL   string
+	fallbackURL string
+	path        string
+	ttl         time.Duration
+	httpClient  *http.Client
+
+	mu          sync.Mutex
+	loaded      bool
+	loadedAt    time.Time
+	lastAttempt time.Time
+	refreshing  bool
+	byIMDb      map[string]indexed
+	byTMDBMovie map[int]indexed
+	byTMDBTV    map[int]indexed
+
+	fbMu    sync.Mutex
+	fbCache map[string]fallbackEntry
+}
+
+// indexed pairs resolved IDs with a season rank so first-season entries win
+// when several dataset rows share the same IMDb/TMDB identifier.
+type indexed struct {
+	ids  IDs
+	rank int
+}
+
+type fallbackEntry struct {
+	ids     IDs
+	ok      bool
+	expires time.Time
+}
+
+// New creates a Mapper. The dataset loads lazily on first Resolve.
+func New(opts Options) *Mapper {
+	if opts.DatasetURL == "" {
+		opts.DatasetURL = DefaultDatasetURL
+	}
+	if opts.MirrorURL == "" {
+		opts.MirrorURL = DefaultDatasetMirrorURL
+	}
+	if opts.FallbackURL == "" {
+		opts.FallbackURL = DefaultFallbackURL
+	}
+	if strings.EqualFold(opts.FallbackURL, "off") {
+		opts.FallbackURL = ""
+	}
+	if opts.TTL <= 0 {
+		opts.TTL = 7 * 24 * time.Hour
+	}
+	if opts.HTTPClient == nil {
+		opts.HTTPClient = &http.Client{Timeout: downloadTimeout}
+	}
+	return &Mapper{
+		datasetURL:  opts.DatasetURL,
+		mirrorURL:   opts.MirrorURL,
+		fallbackURL: strings.TrimRight(opts.FallbackURL, "/"),
+		path:        filepath.Join(opts.CacheDir, datasetFileName),
+		ttl:         opts.TTL,
+		httpClient:  opts.HTTPClient,
+		fbCache:     make(map[string]fallbackEntry),
+	}
+}
+
+// Resolve maps a media ID (IMDb "tt…" or numeric TMDB) to anime-service IDs.
+// mediaType is the render type (poster/backdrop/…) and is only used to break
+// the movie/TV ambiguity of bare numeric TMDB IDs, mirroring the TMDB
+// provider's heuristic. Returns ok=false when the title isn't a known anime.
+func (m *Mapper) Resolve(ctx context.Context, mediaType, id string) (IDs, bool) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return IDs{}, false
+	}
+	m.ensureLoaded()
+
+	m.mu.Lock()
+	ids, ok := m.lookupLocked(mediaType, id)
+	m.mu.Unlock()
+	if ok {
+		return ids, true
+	}
+	return m.resolveFallback(ctx, id)
+}
+
+func (m *Mapper) lookupLocked(mediaType, id string) (IDs, bool) {
+	if strings.HasPrefix(id, "tt") {
+		if e, ok := m.byIMDb[id]; ok {
+			return e.ids, true
+		}
+		return IDs{}, false
+	}
+	n, err := strconv.Atoi(id)
+	if err != nil {
+		return IDs{}, false
+	}
+	// Bare numeric TMDB IDs are ambiguous between movie and TV; follow the
+	// TMDB provider's heuristic (backdrop ⇒ TV first) and try the other space
+	// second rather than failing.
+	first, second := m.byTMDBMovie, m.byTMDBTV
+	if mediaType == "tv" || mediaType == "series" || mediaType == "backdrop" {
+		first, second = m.byTMDBTV, m.byTMDBMovie
+	}
+	if e, ok := first[n]; ok {
+		return e.ids, true
+	}
+	if e, ok := second[n]; ok {
+		return e.ids, true
+	}
+	return IDs{}, false
+}
+
+// ensureLoaded loads the disk cache and downloads the dataset when missing or
+// stale. A missing dataset downloads synchronously (single-flight, throttled);
+// a stale-but-present dataset is served immediately and refreshed in the
+// background so render latency never depends on the upstream host.
+func (m *Mapper) ensureLoaded() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.loaded {
+		if err := m.loadFromDiskLocked(); err == nil {
+			m.loaded = true
+		}
+	}
+	stale := !m.loaded || time.Since(m.loadedAt) > m.ttl
+	if !stale || m.refreshing || time.Since(m.lastAttempt) < retryBackoff {
+		return
+	}
+	m.lastAttempt = time.Now()
+	if m.loaded {
+		m.refreshing = true
+		go m.refresh()
+		return
+	}
+	// No usable dataset at all: block this first caller on the download so
+	// the very first anime render can still succeed.
+	m.mu.Unlock()
+	err := m.downloadAndStore()
+	m.mu.Lock()
+	if err == nil {
+		if err := m.loadFromDiskLocked(); err == nil {
+			m.loaded = true
+		}
+	}
+}
+
+func (m *Mapper) refresh() {
+	err := m.downloadAndStore()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.refreshing = false
+	if err == nil {
+		if err := m.loadFromDiskLocked(); err == nil {
+			m.loaded = true
+		}
+	}
+}
+
+func (m *Mapper) loadFromDiskLocked() error {
+	info, err := os.Stat(m.path)
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(m.path)
+	if err != nil {
+		return err
+	}
+	imdb, movie, tv, err := buildIndexes(data)
+	if err != nil {
+		return err
+	}
+	m.byIMDb, m.byTMDBMovie, m.byTMDBTV = imdb, movie, tv
+	m.loadedAt = info.ModTime()
+	return nil
+}
+
+func (m *Mapper) downloadAndStore() error {
+	data, err := m.fetchDataset(m.datasetURL)
+	if err != nil && m.mirrorURL != "" {
+		data, err = m.fetchDataset(m.mirrorURL)
+	}
+	if err != nil {
+		return err
+	}
+	// Validate before persisting so a bad body never replaces a good cache.
+	if _, _, _, err := buildIndexes(data); err != nil {
+		return fmt.Errorf("animemap: invalid dataset: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(m.path), 0o755); err != nil {
+		return err
+	}
+	tmp := m.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, m.path)
+}
+
+func (m *Mapper) fetchDataset(url string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), downloadTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("animemap: fetch dataset: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("animemap: dataset http %d from %s", resp.StatusCode, url)
+	}
+	lr := &io.LimitedReader{R: resp.Body, N: maxDatasetBytes + 1}
+	data, err := io.ReadAll(lr)
+	if err != nil {
+		return nil, err
+	}
+	if lr.N == 0 {
+		return nil, fmt.Errorf("animemap: dataset exceeds %d bytes", maxDatasetBytes)
+	}
+	return data, nil
+}
+
+// ── dataset parsing ──────────────────────────────────────────────────────────
+
+// flexInt decodes a JSON number or numeric string into an int.
+type flexInt int
+
+func (f *flexInt) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), `"`)
+	if s == "" || s == "null" {
+		*f = 0
+		return nil
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		*f = 0
+		return nil // tolerate odd values (e.g. slugs) rather than failing the load
+	}
+	*f = flexInt(n)
+	return nil
+}
+
+// tmdbRef decodes Fribb's themoviedb_id, which is a bare number for movies or
+// an object like {"tv": 37854} (rarely {"movie": n}) for scoped IDs.
+type tmdbRef struct {
+	Movie int
+	TV    int
+}
+
+func (t *tmdbRef) UnmarshalJSON(b []byte) error {
+	trimmed := strings.TrimSpace(string(b))
+	if trimmed == "" || trimmed == "null" {
+		return nil
+	}
+	if trimmed[0] == '{' {
+		var obj struct {
+			Movie flexInt `json:"movie"`
+			TV    flexInt `json:"tv"`
+		}
+		if err := json.Unmarshal(b, &obj); err != nil {
+			return nil
+		}
+		t.Movie, t.TV = int(obj.Movie), int(obj.TV)
+		return nil
+	}
+	var n flexInt
+	if err := json.Unmarshal(b, &n); err != nil {
+		return nil
+	}
+	t.Movie = int(n)
+	return nil
+}
+
+// seasonRef decodes Fribb's season field ({"tvdb":1,"tmdb":1}, a number, or a
+// string) into a rank: 0 = no season info, 1 = first season, 2 = later season.
+type seasonRef struct{ rank int }
+
+func (s *seasonRef) UnmarshalJSON(b []byte) error {
+	trimmed := strings.TrimSpace(string(b))
+	if trimmed == "" || trimmed == "null" {
+		return nil
+	}
+	season := 0
+	if trimmed[0] == '{' {
+		var obj struct {
+			TMDB flexInt `json:"tmdb"`
+			TVDB flexInt `json:"tvdb"`
+		}
+		if err := json.Unmarshal(b, &obj); err != nil {
+			return nil
+		}
+		season = int(obj.TMDB)
+		if season == 0 {
+			season = int(obj.TVDB)
+		}
+	} else {
+		var n flexInt
+		if err := json.Unmarshal(b, &n); err != nil {
+			return nil
+		}
+		season = int(n)
+	}
+	switch {
+	case season <= 0:
+		s.rank = 0
+	case season == 1:
+		s.rank = 1
+	default:
+		s.rank = 2
+	}
+	return nil
+}
+
+type datasetEntry struct {
+	MALID     flexInt   `json:"mal_id"`
+	AniListID flexInt   `json:"anilist_id"`
+	KitsuID   flexInt   `json:"kitsu_id"`
+	IMDbID    string    `json:"imdb_id"`
+	TMDBID    tmdbRef   `json:"themoviedb_id"`
+	Season    seasonRef `json:"season"`
+}
+
+func buildIndexes(data []byte) (map[string]indexed, map[int]indexed, map[int]indexed, error) {
+	var entries []datasetEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, nil, nil, err
+	}
+	if len(entries) == 0 {
+		return nil, nil, nil, fmt.Errorf("empty dataset")
+	}
+	imdb := make(map[string]indexed)
+	movie := make(map[int]indexed)
+	tv := make(map[int]indexed)
+	for _, e := range entries {
+		ids := IDs{MAL: int(e.MALID), AniList: int(e.AniListID), Kitsu: int(e.KitsuID)}
+		if ids.empty() {
+			continue
+		}
+		item := indexed{ids: ids, rank: e.Season.rank}
+		if e.IMDbID != "" {
+			insert(imdb, e.IMDbID, item)
+		}
+		if e.TMDBID.Movie != 0 {
+			insert(movie, e.TMDBID.Movie, item)
+		}
+		if e.TMDBID.TV != 0 {
+			insert(tv, e.TMDBID.TV, item)
+		}
+	}
+	return imdb, movie, tv, nil
+}
+
+// insert keeps the best-ranked entry per key: season-less or first-season
+// rows beat later seasons, and the first row wins ties (dataset order).
+func insert[K comparable](idx map[K]indexed, key K, item indexed) {
+	if existing, ok := idx[key]; ok && existing.rank <= item.rank {
+		return
+	}
+	idx[key] = item
+}
+
+// ── live API fallback ────────────────────────────────────────────────────────
+
+// resolveFallback queries the live mapping API for IDs the dataset doesn't
+// cover. Results — including misses — are cached so non-anime titles don't
+// trigger a network call on every render.
+func (m *Mapper) resolveFallback(ctx context.Context, id string) (IDs, bool) {
+	if m.fallbackURL == "" {
+		return IDs{}, false
+	}
+
+	m.fbMu.Lock()
+	if e, ok := m.fbCache[id]; ok && time.Now().Before(e.expires) {
+		m.fbMu.Unlock()
+		return e.ids, e.ok
+	}
+	m.fbMu.Unlock()
+
+	source := "themoviedb"
+	if strings.HasPrefix(id, "tt") {
+		source = "imdb"
+	}
+	url := fmt.Sprintf("%s/%s?id=%s&include=myanimelist,anilist,kitsu", m.fallbackURL, source, id)
+
+	fctx, cancel := context.WithTimeout(ctx, fallbackTimeout)
+	defer cancel()
+	ids, found, err := m.fetchFallback(fctx, url)
+	if err != nil {
+		return IDs{}, false // transient failure: don't negative-cache
+	}
+
+	m.fbMu.Lock()
+	if len(m.fbCache) >= fallbackCacheLimit {
+		m.fbCache = make(map[string]fallbackEntry)
+	}
+	m.fbCache[id] = fallbackEntry{ids: ids, ok: found, expires: time.Now().Add(fallbackCacheTTL)}
+	m.fbMu.Unlock()
+	return ids, found
+}
+
+func (m *Mapper) fetchFallback(ctx context.Context, url string) (IDs, bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return IDs{}, false, err
+	}
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return IDs{}, false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return IDs{}, false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return IDs{}, false, fmt.Errorf("animemap: fallback http %d", resp.StatusCode)
+	}
+	var results []struct {
+		MAL     flexInt `json:"myanimelist"`
+		AniList flexInt `json:"anilist"`
+		Kitsu   flexInt `json:"kitsu"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&results); err != nil {
+		return IDs{}, false, err
+	}
+	for _, r := range results {
+		ids := IDs{MAL: int(r.MAL), AniList: int(r.AniList), Kitsu: int(r.Kitsu)}
+		if !ids.empty() {
+			return ids, true, nil
+		}
+	}
+	return IDs{}, false, nil
+}

--- a/internal/provider/animemap/animemap.go
+++ b/internal/provider/animemap/animemap.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -447,11 +448,20 @@ func (m *Mapper) resolveFallback(ctx context.Context, id string) (IDs, bool) {
 	if strings.HasPrefix(id, "tt") {
 		source = "imdb"
 	}
-	url := fmt.Sprintf("%s/%s?id=%s&include=myanimelist,anilist,kitsu", m.fallbackURL, source, id)
+
+	// Construct URL with proper query parameter encoding
+	u, err := url.Parse(m.fallbackURL + "/" + source)
+	if err != nil {
+		return IDs{}, false
+	}
+	q := u.Query()
+	q.Set("id", id)
+	q.Set("include", "myanimelist,anilist,kitsu")
+	u.RawQuery = q.Encode()
 
 	fctx, cancel := context.WithTimeout(ctx, fallbackTimeout)
 	defer cancel()
-	ids, found, err := m.fetchFallback(fctx, url)
+	ids, found, err := m.fetchFallback(fctx, u.String())
 	if err != nil {
 		return IDs{}, false // transient failure: don't negative-cache
 	}

--- a/internal/provider/animemap/animemap_test.go
+++ b/internal/provider/animemap/animemap_test.go
@@ -1,0 +1,220 @@
+package animemap
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// sampleDataset mirrors the Fribb/anime-lists mini-list shape (synthetic IDs).
+const sampleDataset = `[
+  {"type":"TV","mal_id":21,"anilist_id":21,"kitsu_id":12,"imdb_id":"tt0388629","themoviedb_id":{"tv":37854},"tvdb_id":81797},
+  {"type":"MOVIE","mal_id":199,"anilist_id":199,"kitsu_id":176,"imdb_id":"tt0245429","themoviedb_id":129},
+  {"type":"TV","mal_id":50000,"anilist_id":60000,"kitsu_id":70000,"imdb_id":"tt9999999","themoviedb_id":{"tv":4242},"season":{"tvdb":2,"tmdb":2}},
+  {"type":"TV","mal_id":51,"anilist_id":61,"kitsu_id":71,"imdb_id":"tt9999999","themoviedb_id":{"tv":4242},"season":{"tvdb":1,"tmdb":1}},
+  {"type":"TV","anime-planet_id":"slug-only"}
+]`
+
+func newTestMapper(t *testing.T, datasetURL, fallbackURL string) *Mapper {
+	t.Helper()
+	if fallbackURL == "" {
+		fallbackURL = "off"
+	}
+	return New(Options{
+		CacheDir:    t.TempDir(),
+		DatasetURL:  datasetURL,
+		MirrorURL:   datasetURL,
+		FallbackURL: fallbackURL,
+	})
+}
+
+func TestResolveFromDataset(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(sampleDataset))
+	}))
+	defer srv.Close()
+
+	m := newTestMapper(t, srv.URL, "")
+
+	tests := []struct {
+		name, mediaType, id string
+		want                IDs
+		ok                  bool
+	}{
+		{"imdb tv", "poster", "tt0388629", IDs{MAL: 21, AniList: 21, Kitsu: 12}, true},
+		{"imdb movie", "poster", "tt0245429", IDs{MAL: 199, AniList: 199, Kitsu: 176}, true},
+		{"tmdb movie numeric", "poster", "129", IDs{MAL: 199, AniList: 199, Kitsu: 176}, true},
+		{"tmdb tv numeric via backdrop", "backdrop", "37854", IDs{MAL: 21, AniList: 21, Kitsu: 12}, true},
+		{"tmdb tv numeric via poster falls through", "poster", "37854", IDs{MAL: 21, AniList: 21, Kitsu: 12}, true},
+		{"season 1 preferred over season 2", "poster", "tt9999999", IDs{MAL: 51, AniList: 61, Kitsu: 71}, true},
+		{"non-anime", "poster", "tt0468569", IDs{}, false},
+		{"garbage", "poster", "not-an-id", IDs{}, false},
+		{"empty", "poster", "", IDs{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := m.Resolve(context.Background(), tt.mediaType, tt.id)
+			if ok != tt.ok || got != tt.want {
+				t.Errorf("Resolve(%q, %q) = (%+v, %v), want (%+v, %v)",
+					tt.mediaType, tt.id, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestDatasetPersistedToDiskAndReused(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte(sampleDataset))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	m1 := New(Options{CacheDir: dir, DatasetURL: srv.URL, MirrorURL: srv.URL, FallbackURL: "off"})
+	if _, ok := m1.Resolve(context.Background(), "poster", "tt0388629"); !ok {
+		t.Fatal("first mapper: expected mapping")
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("expected 1 dataset download, got %d", hits.Load())
+	}
+	if _, err := os.Stat(filepath.Join(dir, datasetFileName)); err != nil {
+		t.Fatalf("expected dataset file on disk: %v", err)
+	}
+
+	// A fresh mapper over the same cache dir must not re-download.
+	m2 := New(Options{CacheDir: dir, DatasetURL: srv.URL, MirrorURL: srv.URL, FallbackURL: "off"})
+	if _, ok := m2.Resolve(context.Background(), "poster", "tt0388629"); !ok {
+		t.Fatal("second mapper: expected mapping from disk cache")
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("expected disk reuse (1 download), got %d", hits.Load())
+	}
+}
+
+func TestMirrorUsedWhenPrimaryFails(t *testing.T) {
+	mirror := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(sampleDataset))
+	}))
+	defer mirror.Close()
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer primary.Close()
+
+	m := New(Options{
+		CacheDir:    t.TempDir(),
+		DatasetURL:  primary.URL,
+		MirrorURL:   mirror.URL,
+		FallbackURL: "off",
+	})
+	if _, ok := m.Resolve(context.Background(), "poster", "tt0388629"); !ok {
+		t.Fatal("expected mapping via mirror")
+	}
+}
+
+func TestBadDatasetDoesNotReplaceGoodCache(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, datasetFileName)
+	if err := os.WriteFile(path, []byte(sampleDataset), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Make the cache stale so a refresh is attempted.
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"not":"an array"}`))
+	}))
+	defer srv.Close()
+
+	m := New(Options{CacheDir: dir, DatasetURL: srv.URL, MirrorURL: srv.URL, FallbackURL: "off"})
+	if _, ok := m.Resolve(context.Background(), "poster", "tt0388629"); !ok {
+		t.Fatal("expected mapping from existing cache despite bad refresh body")
+	}
+	// Give the async refresh a moment, then confirm the good cache survived.
+	time.Sleep(100 * time.Millisecond)
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != sampleDataset {
+		t.Fatalf("good cache was replaced or unreadable: err=%v", err)
+	}
+}
+
+func TestFallbackResolvesAndCaches(t *testing.T) {
+	dataset := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(sampleDataset))
+	}))
+	defer dataset.Close()
+
+	var fbHits atomic.Int32
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fbHits.Add(1)
+		if r.URL.Query().Get("id") == "tt7654321" {
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"myanimelist": 777, "anilist": 888, "kitsu": 999},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{})
+	}))
+	defer fallback.Close()
+
+	m := New(Options{
+		CacheDir:    t.TempDir(),
+		DatasetURL:  dataset.URL,
+		MirrorURL:   dataset.URL,
+		FallbackURL: fallback.URL,
+	})
+
+	got, ok := m.Resolve(context.Background(), "poster", "tt7654321")
+	want := IDs{MAL: 777, AniList: 888, Kitsu: 999}
+	if !ok || got != want {
+		t.Fatalf("fallback resolve = (%+v, %v), want (%+v, true)", got, ok, want)
+	}
+
+	// Second hit must come from the fallback cache.
+	if _, ok := m.Resolve(context.Background(), "poster", "tt7654321"); !ok {
+		t.Fatal("expected cached fallback mapping")
+	}
+	if fbHits.Load() != 1 {
+		t.Fatalf("expected 1 fallback call, got %d", fbHits.Load())
+	}
+
+	// Misses are negative-cached too.
+	if _, ok := m.Resolve(context.Background(), "poster", "tt1111111"); ok {
+		t.Fatal("expected fallback miss")
+	}
+	if _, ok := m.Resolve(context.Background(), "poster", "tt1111111"); ok {
+		t.Fatal("expected cached fallback miss")
+	}
+	if fbHits.Load() != 2 {
+		t.Fatalf("expected 2 fallback calls total, got %d", fbHits.Load())
+	}
+}
+
+func TestNoDatasetNoFallbackResolvesNothing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	m := newTestMapper(t, srv.URL, "")
+	if _, ok := m.Resolve(context.Background(), "poster", "tt0388629"); ok {
+		t.Fatal("expected no mapping when dataset and fallback are unavailable")
+	}
+}
+
+func TestBuildIndexesRejectsInvalid(t *testing.T) {
+	for _, bad := range []string{"", "{}", "[]", "not json"} {
+		if _, _, _, err := buildIndexes([]byte(bad)); err == nil {
+			t.Errorf("buildIndexes(%q): expected error", bad)
+		}
+	}
+}

--- a/internal/provider/animemapped.go
+++ b/internal/provider/animemapped.go
@@ -1,0 +1,60 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"xrdb_rewrite/internal/provider/animemap"
+)
+
+// AnimeMapped wraps an anime provider (MAL, AniList, Kitsu) so it can serve
+// the render pipeline's native IMDb/TMDB identifiers. Incoming IDs are
+// translated to the wrapped service's ID space via the anime mapper; IDs
+// already carrying the service prefix pass through untouched. Titles with no
+// anime mapping return an error, which the ratings collector ignores.
+type AnimeMapped struct {
+	inner  Provider
+	mapper *animemap.Mapper
+	prefix string
+	pick   func(animemap.IDs) int
+}
+
+// NewAnimeMapped wraps inner with ID translation. inner must be one of the
+// anime providers ("mal", "anilist", "kitsu").
+func NewAnimeMapped(inner Provider, mapper *animemap.Mapper) *AnimeMapped {
+	w := &AnimeMapped{inner: inner, mapper: mapper}
+	switch inner.Name() {
+	case "mal":
+		w.prefix = "mal:"
+		w.pick = func(ids animemap.IDs) int { return ids.MAL }
+	case "anilist":
+		w.prefix = "al:"
+		w.pick = func(ids animemap.IDs) int { return ids.AniList }
+	case "kitsu":
+		w.prefix = "kitsu:"
+		w.pick = func(ids animemap.IDs) int { return ids.Kitsu }
+	default:
+		panic("animemapped: unsupported inner provider " + inner.Name())
+	}
+	return w
+}
+
+// Name satisfies the Provider interface, reporting the inner provider's name.
+func (w *AnimeMapped) Name() string { return w.inner.Name() }
+
+// Fetch translates id to the wrapped service's ID space and delegates.
+func (w *AnimeMapped) Fetch(ctx context.Context, mediaType, id string) (*MediaMeta, error) {
+	if strings.HasPrefix(id, w.prefix) {
+		return w.inner.Fetch(ctx, mediaType, id)
+	}
+	ids, ok := w.mapper.Resolve(ctx, mediaType, id)
+	if !ok {
+		return nil, fmt.Errorf("%s: no anime mapping for id %q", w.inner.Name(), id)
+	}
+	n := w.pick(ids)
+	if n == 0 {
+		return nil, fmt.Errorf("%s: mapping has no %s id for %q", w.inner.Name(), w.inner.Name(), id)
+	}
+	return w.inner.Fetch(ctx, mediaType, fmt.Sprintf("%s%d", w.prefix, n))
+}

--- a/internal/provider/animemapped_test.go
+++ b/internal/provider/animemapped_test.go
@@ -1,0 +1,109 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"xrdb_rewrite/internal/provider/animemap"
+)
+
+const mappedTestDataset = `[
+  {"type":"TV","mal_id":21,"anilist_id":21,"kitsu_id":12,"imdb_id":"tt0388629","themoviedb_id":{"tv":37854}}
+]`
+
+func newTestAnimeMapper(t *testing.T) *animemap.Mapper {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(mappedTestDataset))
+	}))
+	t.Cleanup(srv.Close)
+	return animemap.New(animemap.Options{
+		CacheDir:    t.TempDir(),
+		DatasetURL:  srv.URL,
+		MirrorURL:   srv.URL,
+		FallbackURL: "off",
+	})
+}
+
+func TestAnimeMappedTranslatesIMDbID(t *testing.T) {
+	var gotPath string
+	jikan := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"title":"One Piece","score":8.7,"year":1999}}`))
+	}))
+	defer jikan.Close()
+
+	mal := &MAL{httpClient: jikan.Client(), baseURL: jikan.URL + "/"}
+	w := NewAnimeMapped(mal, newTestAnimeMapper(t))
+
+	meta, err := w.Fetch(context.Background(), "poster", "tt0388629")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !strings.HasSuffix(gotPath, "/21") {
+		t.Errorf("expected upstream call for MAL id 21, got path %q", gotPath)
+	}
+	if len(meta.Ratings) != 1 || meta.Ratings[0].Source != "mal" || meta.Ratings[0].Value != 8.7 {
+		t.Errorf("unexpected ratings: %+v", meta.Ratings)
+	}
+}
+
+func TestAnimeMappedPassesThroughPrefixedID(t *testing.T) {
+	var gotPath string
+	jikan := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"title":"Naruto","score":7.9}}`))
+	}))
+	defer jikan.Close()
+
+	mal := &MAL{httpClient: jikan.Client(), baseURL: jikan.URL + "/"}
+	w := NewAnimeMapped(mal, newTestAnimeMapper(t))
+
+	if _, err := w.Fetch(context.Background(), "poster", "mal:20"); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !strings.HasSuffix(gotPath, "/20") {
+		t.Errorf("expected pass-through to MAL id 20, got path %q", gotPath)
+	}
+}
+
+func TestAnimeMappedRejectsUnmappedID(t *testing.T) {
+	mal := NewMAL()
+	w := NewAnimeMapped(mal, newTestAnimeMapper(t))
+
+	if _, err := w.Fetch(context.Background(), "poster", "tt0468569"); err == nil {
+		t.Fatal("expected error for non-anime id")
+	}
+}
+
+func TestAnimeMappedName(t *testing.T) {
+	m := newTestAnimeMapper(t)
+	for _, tt := range []struct {
+		inner Provider
+		want  string
+	}{
+		{NewMAL(), "mal"},
+		{NewAniList(), "anilist"},
+		{NewKitsu(), "kitsu"},
+	} {
+		if got := NewAnimeMapped(tt.inner, m).Name(); got != tt.want {
+			t.Errorf("Name() = %q, want %q", got, tt.want)
+		}
+	}
+}
+
+func TestAnimeMappedPanicsOnUnsupportedProvider(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for unsupported provider")
+		}
+	}()
+	NewAnimeMapped(NewCinemeta(), newTestAnimeMapper(t))
+}
+
+func TestAnimeMappedImplementsProvider(t *testing.T) {
+	var _ Provider = NewAnimeMapped(NewMAL(), newTestAnimeMapper(t))
+}

--- a/internal/provider/kitsu.go
+++ b/internal/provider/kitsu.go
@@ -16,12 +16,14 @@ const kitsuBaseURL = "https://kitsu.io/api/edge/anime/"
 // IDs must be prefixed with "kitsu:" e.g. "kitsu:7442".
 type Kitsu struct {
 	httpClient *http.Client
+	baseURL    string // overridable for tests; defaults to kitsuBaseURL
 }
 
 // NewKitsu creates a Kitsu provider. No API key is required.
 func NewKitsu() *Kitsu {
 	return &Kitsu{
 		httpClient: &http.Client{Timeout: 10 * time.Second},
+		baseURL:    kitsuBaseURL,
 	}
 }
 
@@ -34,7 +36,11 @@ func (k *Kitsu) Fetch(ctx context.Context, mediaType, id string) (*MediaMeta, er
 		return nil, fmt.Errorf("kitsu: unsupported id %q (expected kitsu:<id>)", id)
 	}
 
-	url := kitsuBaseURL + kitsuID
+	base := k.baseURL
+	if base == "" {
+		base = kitsuBaseURL
+	}
+	url := base + kitsuID
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("kitsu: build request: %w", err)

--- a/internal/provider/mal.go
+++ b/internal/provider/mal.go
@@ -16,12 +16,14 @@ const jikanBaseURL = "https://api.jikan.moe/v4/anime/"
 // IDs must be prefixed with "mal:" e.g. "mal:20".
 type MAL struct {
 	httpClient *http.Client
+	baseURL    string // overridable for tests; defaults to jikanBaseURL
 }
 
 // NewMAL creates a MAL provider. No API key is required (uses public Jikan API).
 func NewMAL() *MAL {
 	return &MAL{
 		httpClient: &http.Client{Timeout: 10 * time.Second},
+		baseURL:    jikanBaseURL,
 	}
 }
 
@@ -34,7 +36,11 @@ func (m *MAL) Fetch(ctx context.Context, mediaType, id string) (*MediaMeta, erro
 		return nil, fmt.Errorf("mal: unsupported id %q (expected mal:<id>)", id)
 	}
 
-	url := jikanBaseURL + malID
+	base := m.baseURL
+	if base == "" {
+		base = jikanBaseURL
+	}
+	url := base + malID
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("mal: build request: %w", err)

--- a/variables.md
+++ b/variables.md
@@ -41,6 +41,20 @@ protect editing that profile (rendering with a profile stays public).
 No key is required for: Cinemeta artwork (Stremio/metahub), MyAnimeList,
 AniList, and Kitsu ratings — those work out of the box.
 
+## Anime ID mapping
+
+Anime ratings need the render ID (IMDb/TMDB) translated to MAL/AniList/Kitsu
+IDs. XRDB downloads the community
+[Fribb/anime-lists](https://github.com/Fribb/anime-lists) dataset (~6 MB) into
+`XRDB_CACHE_DIR` on first use, refreshes it weekly, and keeps serving the
+cached copy if the source is unreachable. Titles missing from the dataset fall
+back to a live per-ID lookup.
+
+| Variable | Default | Description |
+|---|---|---|
+| `XRDB_ANIME_MAP_URL` | Fribb anime-lists (GitHub raw, jsDelivr mirror) | Override the mapping dataset URL. |
+| `XRDB_ANIME_MAP_FALLBACK_URL` | `https://arm.haglund.dev/api/v2` | Live per-ID mapping API for titles the dataset misses. Set to `off` to disable. |
+
 ## Cache tuning
 
 | Variable | Default | Description |

--- a/variables.md
+++ b/variables.md
@@ -52,7 +52,7 @@ back to a live per-ID lookup.
 
 | Variable | Default | Description |
 |---|---|---|
-| `XRDB_ANIME_MAP_URL` | Fribb anime-lists (GitHub raw, jsDelivr mirror) | Override the mapping dataset URL. |
+| `XRDB_ANIME_MAP_URL` | Fribb anime-lists (GitHub raw, jsDelivr mirror) | Override the primary mapping dataset URL. **Note:** The mapper uses a hard-coded jsDelivr/GitHub raw mirror as fallback when the primary source is unreachable. For self-hosted or air-gapped deployments requiring full URL control, the mirror must be changed in the mapper source code. |
 | `XRDB_ANIME_MAP_FALLBACK_URL` | `https://arm.haglund.dev/api/v2` | Live per-ID mapping API for titles the dataset misses. Set to `off` to disable. |
 | `XRDB_ANIME_MAP_REFRESH_HOURS` | `168` (7 days) | How old the cached dataset may get before a background re-download. Refreshes never block renders; a failed refresh keeps the existing copy. |
 

--- a/variables.md
+++ b/variables.md
@@ -54,6 +54,7 @@ back to a live per-ID lookup.
 |---|---|---|
 | `XRDB_ANIME_MAP_URL` | Fribb anime-lists (GitHub raw, jsDelivr mirror) | Override the mapping dataset URL. |
 | `XRDB_ANIME_MAP_FALLBACK_URL` | `https://arm.haglund.dev/api/v2` | Live per-ID mapping API for titles the dataset misses. Set to `off` to disable. |
+| `XRDB_ANIME_MAP_REFRESH_HOURS` | `168` (7 days) | How old the cached dataset may get before a background re-download. Refreshes never block renders; a failed refresh keeps the existing copy. |
 
 ## Cache tuning
 


### PR DESCRIPTION
## Problem

Anime titles render **no MAL / AniList / Kitsu ratings** in v3 (verified live), and v2.2.2 broke the same way. Two distinct causes:

1. **v2** depends on a single third-party mapping host, `animemapping.stremio.dpdns.org`, which is now **NXDOMAIN** (dead DNS).
2. **v3 never had a mapping layer at all**: the render pipeline fans the raw IMDb/TMDB ID out to every provider, but `mal.go`/`anilist.go`/`kitsu.go` only accept `mal:`/`al:`/`kitsu:` prefixed IDs — so the anime providers errored on every render and silently contributed nothing.

## Fix

New `internal/provider/animemap` package — XRDB now owns its mapping instead of depending on a hobby DNS host:

- **Primary source:** the community [Fribb/anime-lists](https://github.com/Fribb/anime-lists) dataset (~6 MB, 42k titles), downloaded into `XRDB_CACHE_DIR/anime-map.json` on first use (GitHub raw, jsDelivr mirror as backup), refreshed weekly **in the background**, and served stale if upstream is unreachable. After the first download, anime mapping works fully offline.
- **Fallback:** titles missing from the dataset resolve via a live per-ID API (`arm.haglund.dev`) with positive **and negative** caching, so non-anime titles never trigger repeat network calls.
- **Wiring:** a small `AnimeMapped` provider adapter translates IMDb/TMDB IDs before delegating to MAL/AniList/Kitsu; prefixed IDs pass through. The compose pipeline is untouched.
- Season-aware index: when several dataset rows share an IMDb/TMDB ID, season-1/base entries win.
- New env vars: `XRDB_ANIME_MAP_URL`, `XRDB_ANIME_MAP_FALLBACK_URL` (`off` disables the live fallback). Documented in `variables.md`.
- Anime provider base URLs are now injectable — the previous anime provider tests never exercised the HTTP path; the new tests do.

## Testing

- `go test ./...` — 230 tests green (was 208), including `-race` on the new package.
- Local end-to-end on `:8799`:
  - `/poster/tt0388629` (One Piece) → IMDb 8.7, TMDB 9.0, **MAL 8.7, AniList 8.7, Kitsu 8.4** badges rendered
  - `/poster/tt0245429` (Spirited Away) → **MAL/AniList/Kitsu badges rendered**
  - `/poster/tt0468569` (The Dark Knight, control) → IMDb only, no anime calls leak through
  - Dataset cached to disk once; restart reuses it with zero downloads

## Notes

- Bare numeric TMDB **TV** IDs (e.g. `/poster/37854`) still render a placeholder — pre-existing TMDB artwork-path movie/TV ambiguity, unrelated to mapping; tracked separately.
