### PR TITLE
fix(configurator): quality pass — scaling, layout bugs, cache buster, AIOM dropdown

### DIFF
--- a/internal/compose/badge.go
+++ b/internal/compose/badge.go
@@ -1,6 +1,7 @@
 package compose
 
 import (
+	"bytes"
 	"embed"
 	"image"
 	"image/color"
@@ -26,15 +27,18 @@ var ratingIconFS embed.FS
 var (
 	onceFaces sync.Once
 	faceValue font.Face // 14px bold — rating value (normal scale)
-	faceLabel font.Face // 9px regular — small labels (overlays)
+	faceLabel font.Face // 11px regular — overlay labels (normal scale)
 
 	onceIcons   sync.Once
 	ratingIcons map[string]image.Image
 
-	fontBoldParsed *opentype.Font
+	fontBoldParsed    *opentype.Font
+	fontRegularParsed *opentype.Font
 
-	// scaledFaces caches value faces for non-1 output scales (large/4k).
-	scaledFaces sync.Map // float64 → font.Face
+	// scaledValueFaces / scaledLabelFaces cache faces keyed by int(scale*100)
+	// to avoid float64 map key precision issues.
+	scaledValueFaces sync.Map
+	scaledLabelFaces sync.Map
 )
 
 func ensureFaces() {
@@ -53,12 +57,15 @@ func ensureFaces() {
 		}
 		if tt, err := opentype.Parse(goregular.TTF); err != nil {
 			log.Printf("compose: parse regular font: %v", err)
-		} else if f, err := opentype.NewFace(tt, &opentype.FaceOptions{
-			Size: 9, DPI: 72, Hinting: font.HintingFull,
-		}); err != nil {
-			log.Printf("compose: create regular face: %v", err)
 		} else {
-			faceLabel = f
+			fontRegularParsed = tt
+			if f, err := opentype.NewFace(tt, &opentype.FaceOptions{
+				Size: 11, DPI: 72, Hinting: font.HintingFull,
+			}); err != nil {
+				log.Printf("compose: create regular face: %v", err)
+			} else {
+				faceLabel = f
+			}
 		}
 	})
 }
@@ -76,7 +83,7 @@ func ensureIcons() {
 			if err != nil {
 				continue
 			}
-			img, err := png.Decode(strings.NewReader(string(data)))
+			img, err := png.Decode(bytes.NewReader(data))
 			if err != nil {
 				continue
 			}
@@ -85,12 +92,13 @@ func ensureIcons() {
 	})
 }
 
-// valueFaceFor returns a bold value face sized for the output scale.
+// valueFaceFor returns a bold face scaled for the output size.
 func valueFaceFor(scale float64) font.Face {
 	if scale == 1 || fontBoldParsed == nil {
 		return faceValue
 	}
-	if f, ok := scaledFaces.Load(scale); ok {
+	key := int(scale * 100)
+	if f, ok := scaledValueFaces.Load(key); ok {
 		return f.(font.Face)
 	}
 	f, err := opentype.NewFace(fontBoldParsed, &opentype.FaceOptions{
@@ -99,7 +107,27 @@ func valueFaceFor(scale float64) font.Face {
 	if err != nil {
 		return faceValue
 	}
-	scaledFaces.Store(scale, f)
+	scaledValueFaces.Store(key, f)
+	return f
+}
+
+// labelFaceFor returns a regular face scaled for the output size.
+// Used by badge_overlay.go for quality/provider/genre label text.
+func labelFaceFor(scale float64) font.Face {
+	if scale == 1 || fontRegularParsed == nil {
+		return faceLabel
+	}
+	key := int(scale * 100)
+	if f, ok := scaledLabelFaces.Load(key); ok {
+		return f.(font.Face)
+	}
+	f, err := opentype.NewFace(fontRegularParsed, &opentype.FaceOptions{
+		Size: 11 * scale, DPI: 72, Hinting: font.HintingFull,
+	})
+	if err != nil {
+		return faceLabel
+	}
+	scaledLabelFaces.Store(key, f)
 	return f
 }
 
@@ -121,7 +149,7 @@ var providerAccent = map[string]color.NRGBA{
 	"tmdb":       {R: 1, G: 180, B: 228, A: 255},
 	"imdb":       {R: 245, G: 197, B: 24, A: 255},
 	"rt":         {R: 250, G: 50, B: 10, A: 255},
-	"rtaudience":  {R: 250, G: 130, B: 10, A: 255},
+	"rtaudience": {R: 250, G: 130, B: 10, A: 255},
 	"metacritic": {R: 255, G: 204, B: 52, A: 255},
 	"mdblist":    {R: 139, G: 92, B: 246, A: 255},
 	"letterboxd": {R: 0, G: 169, B: 157, A: 255},
@@ -167,42 +195,97 @@ func chromeFor(cfg imageconfig.Config) badgeChrome {
 	case imageconfig.BadgeSquare:
 		c.radius = func(int) int { return 0 }
 	case imageconfig.BadgeGlass:
-		// Capsule shape, see-through fill, hairline edge.
+		// Outline style: fully transparent fill, rounded capsule, visible border only.
+		// Visually distinct from Pill (which has a solid fill).
 		c.radius = func(innerH int) int { return innerH / 2 }
-		c.bg = color.NRGBA{R: 16, G: 16, B: 24, A: 110}
-		c.border = color.NRGBA{R: 255, G: 255, B: 255, A: 70}
+		c.bg = color.NRGBA{A: 0}
+		c.border = color.NRGBA{R: 255, G: 255, B: 255, A: 200}
 	case imageconfig.BadgePill:
-		// True capsule: fully rounded ends.
+		// Solid capsule: fully rounded ends, opaque fill.
 		c.radius = func(innerH int) int { return innerH / 2 }
 	}
 	if cfg.BadgeTheme == imageconfig.ThemeLight {
-		c.bg = color.NRGBA{R: 246, G: 246, B: 248, A: 240}
-		c.valueColor = color.NRGBA{R: 18, G: 18, B: 24, A: 255}
-		c.iconColor = color.NRGBA{R: 30, G: 30, B: 38, A: 255}
 		if cfg.BadgeStyle == imageconfig.BadgeGlass {
-			c.bg = color.NRGBA{R: 246, G: 246, B: 248, A: 165}
-			c.border = color.NRGBA{R: 0, G: 0, B: 0, A: 60}
+			c.bg = color.NRGBA{A: 0}
+			c.border = color.NRGBA{R: 0, G: 0, B: 0, A: 200}
+			c.valueColor = color.NRGBA{R: 18, G: 18, B: 24, A: 255}
+			c.iconColor = color.NRGBA{R: 30, G: 30, B: 38, A: 255}
+		} else {
+			c.bg = color.NRGBA{R: 246, G: 246, B: 248, A: 240}
+			c.valueColor = color.NRGBA{R: 18, G: 18, B: 24, A: 255}
+			c.iconColor = color.NRGBA{R: 30, G: 30, B: 38, A: 255}
 		}
 	}
 	return c
 }
 
+// badgeSpec holds pre-computed layout info for a single rating badge.
+type badgeSpec struct {
+	value  string
+	valW   int
+	icon   image.Image
+	w      int
+	accent color.NRGBA
+	x      int // resolved x position, set during layout
+}
+
+// drawRatingRow renders a horizontal slice of badge specs at row y.
+func drawRatingRow(out *image.NRGBA, specs []badgeSpec, y, innerH, padX, iconSize, iconGap, accentW int, face font.Face, chrome badgeChrome) {
+	radius := chrome.radius(innerH)
+	fm := face.Metrics()
+	valAscent := fm.Ascent.Ceil()
+	valDescent := fm.Descent.Ceil()
+	valH := valAscent + valDescent
+
+	for _, sp := range specs {
+		bRect := image.Rect(sp.x, y, sp.x+sp.w, y+innerH)
+		if chrome.bg.A > 0 {
+			fillRoundedRect(out, bRect, radius, chrome.bg)
+		}
+		if chrome.border.A > 0 {
+			drawRectBorder(out, bRect, radius, chrome.border)
+		}
+
+		iconTint := chrome.iconColor
+		contentX := sp.x
+		if radius < innerH/2 {
+			aRect := image.Rect(sp.x, y, sp.x+accentW, y+innerH)
+			fillRect(out, aRect.Intersect(bRect), sp.accent)
+			contentX += accentW
+		} else {
+			iconTint = sp.accent
+		}
+		contentX += padX
+
+		if sp.icon != nil {
+			iRect := image.Rect(contentX, y+(innerH-iconSize)/2, contentX+iconSize, y+(innerH-iconSize)/2+iconSize)
+			drawTintedIcon(out, iRect, sp.icon, iconTint)
+			contentX += iconSize + iconGap
+		}
+
+		valY := y + (innerH-valH)/2 + valAscent
+		drawText(out, face, contentX, valY, chrome.valueColor, sp.value)
+	}
+}
+
 // drawBadgesInPlace composites rating badges onto out according to the render config.
-// Badges carry the provider's official glyph plus the score, wrap onto
-// multiple rows when they would overflow, and scale with the output size.
-func drawBadgesInPlace(out *image.NRGBA, ratings []provider.Rating, cfg imageconfig.Config) {
+// Returns the pixel height consumed (zero when layout is none).
+func drawBadgesInPlace(out *image.NRGBA, ratings []provider.Rating, cfg imageconfig.Config) int {
+	if cfg.RatingsLayout == imageconfig.LayoutNone {
+		return 0
+	}
 	if len(ratings) == 0 {
-		return
+		return 0
 	}
 	ensureFaces()
 	ensureIcons()
 	if faceValue == nil {
-		return
+		return 0
 	}
 
 	filtered := filterRatings(ratings, cfg.Ratings)
 	if len(filtered) == 0 {
-		return
+		return 0
 	}
 
 	scale := outputScale(cfg.Size)
@@ -216,27 +299,18 @@ func drawBadgesInPlace(out *image.NRGBA, ratings []provider.Rating, cfg imagecon
 
 	var (
 		accentW  = s(3)
-		padX     = s(8)
-		padY     = s(5)
-		iconSize = s(15)
+		padX     = s(9)
+		padY     = s(6)
+		iconSize = s(17)
 		iconGap  = s(5)
-		badgeGap = s(6)
-		rowGap   = s(6)
-		edgeX    = s(10)
-		edgeY    = s(10)
+		badgeGap = s(7)
+		rowGap   = s(7)
+		edgeX    = s(12)
+		edgeY    = s(12)
 	)
 
 	innerH := padY*2 + maxInt(valH, iconSize)
 	chrome := chromeFor(cfg)
-	radius := chrome.radius(innerH)
-
-	type badgeSpec struct {
-		value  string
-		valW   int
-		icon   image.Image
-		w      int
-		accent color.NRGBA
-	}
 
 	bounds := out.Bounds()
 	maxRowW := bounds.Dx() - edgeX*2
@@ -262,8 +336,11 @@ func drawBadgesInPlace(out *image.NRGBA, ratings []provider.Rating, cfg imagecon
 		})
 	}
 
-	// Greedy row wrap: keep badge order, start a new row when the next badge
-	// would overflow the drawable width.
+	if cfg.RatingsLayout == imageconfig.LayoutSplitSide {
+		return drawBadgesSplitSide(out, specs, innerH, rowGap, edgeX, edgeY, padX, iconSize, iconGap, accentW, face, chrome, bounds)
+	}
+
+	// Greedy row wrap for top/bottom layouts.
 	var rows [][]badgeSpec
 	var row []badgeSpec
 	rowW := 0
@@ -286,8 +363,12 @@ func drawBadgesInPlace(out *image.NRGBA, ratings []provider.Rating, cfg imagecon
 	}
 
 	totalH := len(rows)*innerH + (len(rows)-1)*rowGap
+
 	startY := bounds.Max.Y - edgeY - totalH
 	if cfg.RatingsLayout == imageconfig.LayoutTop {
+		startY = bounds.Min.Y + edgeY
+	}
+	if startY < bounds.Min.Y+edgeY {
 		startY = bounds.Min.Y + edgeY
 	}
 
@@ -304,40 +385,49 @@ func drawBadgesInPlace(out *image.NRGBA, ratings []provider.Rating, cfg imagecon
 		if x < bounds.Min.X+edgeX {
 			x = bounds.Min.X + edgeX
 		}
-		for _, sp := range r {
-			bRect := image.Rect(x, y, x+sp.w, y+innerH)
-			fillRoundedRect(out, bRect, radius, chrome.bg)
-			if chrome.border.A > 0 {
-				drawRectBorder(out, bRect, radius, chrome.border)
-			}
-
-			// Accent strip hugs the left edge. Skip it on capsule shapes
-			// where a straight strip would poke out of the round end —
-			// tint the icon with the provider accent instead.
-			iconTint := chrome.iconColor
-			contentX := x
-			if radius < innerH/2 {
-				aRect := image.Rect(x, y, x+accentW, y+innerH)
-				fillRect(out, aRect.Intersect(bRect), sp.accent)
-				contentX += accentW
-			} else {
-				iconTint = sp.accent
-			}
-			contentX += padX
-
-			if sp.icon != nil {
-				iRect := image.Rect(contentX, y+(innerH-iconSize)/2, contentX+iconSize, y+(innerH-iconSize)/2+iconSize)
-				drawTintedIcon(out, iRect, sp.icon, iconTint)
-				contentX += iconSize + iconGap
-			}
-
-			valY := y + (innerH-valH)/2 + valAscent
-			drawText(out, face, contentX, valY, chrome.valueColor, sp.value)
-
-			x += sp.w + badgeGap
+		for i := range r {
+			r[i].x = x
+			x += r[i].w + badgeGap
 		}
+		drawRatingRow(out, r, y, innerH, padX, iconSize, iconGap, accentW, face, chrome)
 		y += innerH + rowGap
 	}
+
+	return totalH
+}
+
+// drawBadgesSplitSide renders the first half of badges vertically on the left
+// edge and the second half on the right edge, both centered vertically.
+func drawBadgesSplitSide(out *image.NRGBA, specs []badgeSpec, innerH, rowGap, edgeX, edgeY, padX, iconSize, iconGap, accentW int, face font.Face, chrome badgeChrome, bounds image.Rectangle) int {
+	if len(specs) == 0 {
+		return 0
+	}
+	mid := (len(specs) + 1) / 2
+	left := specs[:mid]
+	right := specs[mid:]
+
+	leftH := len(left)*innerH + (len(left)-1)*rowGap
+	rightH := len(right)*innerH + (len(right)-1)*rowGap
+	totalH := maxInt(leftH, rightH)
+
+	midY := bounds.Min.Y + bounds.Dy()/2
+
+	y := midY - leftH/2
+	for i := range left {
+		left[i].x = bounds.Min.X + edgeX
+		drawRatingRow(out, left[i:i+1], y, innerH, padX, iconSize, iconGap, accentW, face, chrome)
+		y += innerH + rowGap
+	}
+
+	y = midY - rightH/2
+	for i := range right {
+		right[i].x = bounds.Max.X - edgeX - right[i].w
+		drawRatingRow(out, right[i:i+1], y, innerH, padX, iconSize, iconGap, accentW, face, chrome)
+		y += innerH + rowGap
+	}
+
+	_ = edgeY
+	return totalH
 }
 
 func maxInt(a, b int) int {

--- a/internal/compose/badge_overlay.go
+++ b/internal/compose/badge_overlay.go
@@ -55,26 +55,26 @@ func qualityBadgeLabel(token string) string {
 }
 
 // drawQualityBadges renders quality/format badges (4K, HDR, DV, …) stacked
-// in the top-right corner of the image.
-func drawQualityBadges(base *image.NRGBA, tokens []string) {
+// in the top-right corner. Returns the total pixel height consumed.
+func drawQualityBadges(base *image.NRGBA, tokens []string, scale float64) int {
 	if len(tokens) == 0 {
-		return
+		return 0
 	}
 	ensureFaces()
-	if faceLabel == nil {
-		return
+	face := labelFaceFor(scale)
+	if face == nil {
+		return 0
 	}
 
-	const (
-		padX     = 6
-		padY     = 4
-		badgeGap = 4
-		edgeX    = 10
-		edgeY    = 10
-		radius   = 3
-	)
+	s := func(v float64) int { return int(v*scale + 0.5) }
+	padX := s(6)
+	padY := s(4)
+	badgeGap := s(4)
+	edgeX := s(10)
+	edgeY := s(10)
+	radius := s(3)
 
-	lm := faceLabel.Metrics()
+	lm := face.Metrics()
 	lAscent := lm.Ascent.Ceil()
 	lDescent := lm.Descent.Ceil()
 	badgeH := padY*2 + lAscent + lDescent
@@ -84,40 +84,42 @@ func drawQualityBadges(base *image.NRGBA, tokens []string) {
 	y := bounds.Min.Y + edgeY
 	for _, tok := range tokens {
 		label := qualityBadgeLabel(tok)
-		lw := textWidth(faceLabel, label)
+		lw := textWidth(face, label)
 		bw := padX*2 + lw
 		x := bounds.Max.X - edgeX - bw
 		bRect := image.Rect(x, y, x+bw, y+badgeH)
 		fillRoundedRect(base, bRect, radius, qualityBadgeColor(tok))
 		tx := x + padX
 		ty := y + padY + lAscent
-		drawText(base, faceLabel, tx, ty, color.White, label)
+		drawText(base, face, tx, ty, color.White, label)
 		y += badgeH + badgeGap
 	}
+
+	return len(tokens)*badgeH + (len(tokens)-1)*badgeGap
 }
 
 // ── Age rating badge ──────────────────────────────────────────────────────────
 
 // drawAgeRatingBadge renders a content rating badge (e.g. "TV-MA", "R")
 // in the corner specified by pos ("tl", "tr", "bl", "br", "inherit").
-// "inherit" defaults to "tl".
-func drawAgeRatingBadge(base *image.NRGBA, rating string, pos string) {
+// "inherit" defaults to "br" so it does not conflict with the trending badge (TL)
+// or quality badges (TR).
+func drawAgeRatingBadge(base *image.NRGBA, rating string, pos string, scale float64) {
 	if rating == "" {
 		return
 	}
 	ensureFaces()
-	face := faceLabel
+	face := labelFaceFor(scale)
 	if face == nil {
 		return
 	}
 
-	const (
-		padX   = 7
-		padY   = 4
-		edgeX  = 10
-		edgeY  = 10
-		radius = 3
-	)
+	s := func(v float64) int { return int(v*scale + 0.5) }
+	padX := s(7)
+	padY := s(4)
+	edgeX := s(10)
+	edgeY := s(10)
+	radius := s(3)
 
 	fm := face.Metrics()
 	ascent := fm.Ascent.Ceil()
@@ -129,23 +131,23 @@ func drawAgeRatingBadge(base *image.NRGBA, rating string, pos string) {
 
 	resolvedPos := pos
 	if resolvedPos == "" || resolvedPos == "inherit" {
-		resolvedPos = "tl"
+		resolvedPos = "br"
 	}
 
 	var x, y int
 	switch resolvedPos {
+	case "tl":
+		x = bounds.Min.X + edgeX
+		y = bounds.Min.Y + edgeY
 	case "tr":
 		x = bounds.Max.X - edgeX - bw
 		y = bounds.Min.Y + edgeY
 	case "bl":
 		x = bounds.Min.X + edgeX
 		y = bounds.Max.Y - edgeY - bh
-	case "br":
+	default: // "br"
 		x = bounds.Max.X - edgeX - bw
 		y = bounds.Max.Y - edgeY - bh
-	default: // "tl"
-		x = bounds.Min.X + edgeX
-		y = bounds.Min.Y + edgeY
 	}
 
 	bg := color.NRGBA{R: 30, G: 30, B: 30, A: 220}
@@ -208,12 +210,12 @@ func shortProviderName(name string) string {
 // drawProviderBadges renders streaming provider chips as a horizontal row
 // along the bottom of the image, above any ratings strip.
 // At most 4 providers are shown to avoid crowding.
-func drawProviderBadges(base *image.NRGBA, providers []provider.WatchProvider) {
+func drawProviderBadges(base *image.NRGBA, providers []provider.WatchProvider, scale float64) {
 	if len(providers) == 0 {
 		return
 	}
 	ensureFaces()
-	face := faceLabel
+	face := labelFaceFor(scale)
 	if face == nil {
 		return
 	}
@@ -223,14 +225,13 @@ func drawProviderBadges(base *image.NRGBA, providers []provider.WatchProvider) {
 		shown = shown[:4]
 	}
 
-	const (
-		padX     = 6
-		padY     = 3
-		badgeGap = 5
-		edgeX    = 10
-		edgeY    = 55 // above ratings strip
-		radius   = 3
-	)
+	s := func(v float64) int { return int(v*scale + 0.5) }
+	padX := s(6)
+	padY := s(3)
+	badgeGap := s(5)
+	edgeX := s(10)
+	edgeY := s(55) // above ratings strip
+	radius := s(3)
 
 	fm := face.Metrics()
 	ascent := fm.Ascent.Ceil()
@@ -243,14 +244,13 @@ func drawProviderBadges(base *image.NRGBA, providers []provider.WatchProvider) {
 		label string
 		w     int
 		color color.NRGBA
-		prov  provider.WatchProvider
 	}
 	specs := make([]spec, 0, len(shown))
 	totalW := 0
 	for i, p := range shown {
 		lbl := shortProviderName(p.Name)
 		lw := padX*2 + textWidth(face, lbl)
-		specs = append(specs, spec{label: lbl, w: lw, color: providerColor(p.ID), prov: p})
+		specs = append(specs, spec{label: lbl, w: lw, color: providerColor(p.ID)})
 		totalW += lw
 		if i > 0 {
 			totalW += badgeGap
@@ -263,13 +263,13 @@ func drawProviderBadges(base *image.NRGBA, providers []provider.WatchProvider) {
 	}
 	y := bounds.Max.Y - edgeY - badgeH
 
-	for _, s := range specs {
-		bRect := image.Rect(x, y, x+s.w, y+badgeH)
-		fillRoundedRect(base, bRect, radius, s.color)
+	for _, sp := range specs {
+		bRect := image.Rect(x, y, x+sp.w, y+badgeH)
+		fillRoundedRect(base, bRect, radius, sp.color)
 		tx := x + padX
 		ty := y + padY + ascent
-		drawText(base, face, tx, ty, color.White, s.label)
-		x += s.w + badgeGap
+		drawText(base, face, tx, ty, color.White, sp.label)
+		x += sp.w + badgeGap
 	}
 }
 
@@ -277,12 +277,12 @@ func drawProviderBadges(base *image.NRGBA, providers []provider.WatchProvider) {
 
 // drawGenreBadge renders a genre pill at the bottom-left corner (or pos).
 // Shows at most 3 genres separated by " · ".
-func drawGenreBadge(base *image.NRGBA, genres []string, pos string) {
+func drawGenreBadge(base *image.NRGBA, genres []string, pos string, scale float64) {
 	if len(genres) == 0 {
 		return
 	}
 	ensureFaces()
-	face := faceLabel
+	face := labelFaceFor(scale)
 	if face == nil {
 		return
 	}
@@ -293,13 +293,12 @@ func drawGenreBadge(base *image.NRGBA, genres []string, pos string) {
 	}
 	label := strings.Join(shown, " · ")
 
-	const (
-		padX   = 8
-		padY   = 4
-		edgeX  = 10
-		edgeY  = 10
-		radius = 3
-	)
+	s := func(v float64) int { return int(v*scale + 0.5) }
+	padX := s(8)
+	padY := s(4)
+	edgeX := s(10)
+	edgeY := s(10)
+	radius := s(3)
 
 	fm := face.Metrics()
 	ascent := fm.Ascent.Ceil()
@@ -348,7 +347,6 @@ func drawAggregateBar(base *image.NRGBA, ratings []provider.Rating, cfg imagecon
 	if len(ratings) == 0 {
 		return
 	}
-	ensureFaces()
 
 	allowed := make(map[string]bool, len(cfg.Ratings))
 	for _, r := range cfg.Ratings {
@@ -371,10 +369,15 @@ func drawAggregateBar(base *image.NRGBA, ratings []provider.Rating, cfg imagecon
 	}
 	avg := sum / float64(n) // 0–10 scale
 
+	scale := outputScale(cfg.Size)
+	barH := int(10*scale + 0.5)
+	if barH < 4 {
+		barH = 4
+	}
+
 	bounds := base.Bounds()
 	w := bounds.Dx()
 
-	const barH = 10
 	var barY int
 	pos := strings.ToLower(cfg.AggregateBarPos)
 	if pos == "top" {
@@ -410,27 +413,28 @@ func drawAggregateBar(base *image.NRGBA, ratings []provider.Rating, cfg imagecon
 
 // ── Trending badge ────────────────────────────────────────────────────────────
 
-// drawTrendingBadge draws a small "TRENDING" label badge at the top-left corner.
-func drawTrendingBadge(base *image.NRGBA) {
+// drawTrendingBadge draws a "TRENDING" label badge at the top-left corner.
+func drawTrendingBadge(base *image.NRGBA, scale float64) {
 	ensureFaces()
-	if faceLabel == nil {
+	face := labelFaceFor(scale)
+	if face == nil {
 		return
 	}
 
-	const (
-		label  = "TRENDING"
-		padX   = 7
-		padY   = 4
-		edgeX  = 8
-		edgeY  = 8
-		radius = 3
-	)
+	const label = "TRENDING"
 
-	fm := faceLabel.Metrics()
+	s := func(v float64) int { return int(v*scale + 0.5) }
+	padX := s(7)
+	padY := s(4)
+	edgeX := s(8)
+	edgeY := s(8)
+	radius := s(3)
+
+	fm := face.Metrics()
 	ascent := fm.Ascent.Ceil()
 	descent := fm.Descent.Ceil()
 	bh := padY*2 + ascent + descent
-	bw := padX*2 + textWidth(faceLabel, label)
+	bw := padX*2 + textWidth(face, label)
 
 	bounds := base.Bounds()
 	x := bounds.Min.X + edgeX
@@ -438,5 +442,5 @@ func drawTrendingBadge(base *image.NRGBA) {
 
 	bg := color.NRGBA{R: 231, G: 76, B: 60, A: 230}
 	fillRoundedRect(base, image.Rect(x, y, x+bw, y+bh), radius, bg)
-	drawText(base, faceLabel, x+padX, y+padY+ascent, color.NRGBA{R: 255, G: 255, B: 255, A: 255}, label)
+	drawText(base, face, x+padX, y+padY+ascent, color.NRGBA{R: 255, G: 255, B: 255, A: 255}, label)
 }

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -130,28 +130,30 @@ func (p *Pipeline) Render(ctx context.Context, req Request) (*Result, error) {
 	// Convert to NRGBA once — all overlay functions draw in-place.
 	composed := toNRGBA(resized)
 
+	scale := outputScale(req.Config.Size)
+
 	allRatings, ratingProviders := p.collectRatingsWithProviders(ctx, req, meta.Ratings)
 	result.ContributingProviders = append([]string{string(req.Config.ArtworkSource)}, ratingProviders...)
 	if len(allRatings) > 0 && len(req.Config.Ratings) > 0 {
 		drawBadgesInPlace(composed, allRatings, req.Config)
 	}
 	if len(req.Config.Badges) > 0 {
-		drawQualityBadges(composed, req.Config.Badges)
+		drawQualityBadges(composed, req.Config.Badges, scale)
 	}
 	if req.Config.AgeRating && meta.ContentRating != "" {
-		drawAgeRatingBadge(composed, meta.ContentRating, req.Config.AgeRatingPos)
+		drawAgeRatingBadge(composed, meta.ContentRating, req.Config.AgeRatingPos, scale)
 	}
 	if req.Config.Genre && len(meta.Genres) > 0 {
-		drawGenreBadge(composed, meta.Genres, req.Config.GenrePos)
+		drawGenreBadge(composed, meta.Genres, req.Config.GenrePos, scale)
 	}
 	if req.Config.Providers && len(meta.WatchProviders) > 0 {
-		drawProviderBadges(composed, meta.WatchProviders)
+		drawProviderBadges(composed, meta.WatchProviders, scale)
 	}
 	if req.Config.AggregateBar {
 		drawAggregateBar(composed, allRatings, req.Config)
 	}
 	if req.Config.Trending {
-		drawTrendingBadge(composed)
+		drawTrendingBadge(composed, scale)
 	}
 
 	var buf bytes.Buffer
@@ -193,7 +195,7 @@ func (p *Pipeline) fetchSourceImageAndMeta(ctx context.Context, req Request) ([]
 
 	p.enrichMetaForOverlays(ctx, req, meta)
 
-	artworkURL := selectArtworkURL(meta, req.MediaType)
+	artworkURL := selectArtworkURL(meta, req.MediaType, req.Config)
 	if artworkURL == "" {
 		return nil, meta, fmt.Errorf("no artwork URL in metadata")
 	}
@@ -232,7 +234,7 @@ func (p *Pipeline) enrichMetaForOverlays(ctx context.Context, req Request, meta 
 	}
 }
 
-func selectArtworkURL(meta *provider.MediaMeta, mediaType string) string {
+func selectArtworkURL(meta *provider.MediaMeta, mediaType string, cfg imageconfig.Config) string {
 	switch mediaType {
 	case "backdrop":
 		return meta.BackdropURL
@@ -249,6 +251,11 @@ func selectArtworkURL(meta *provider.MediaMeta, mediaType string) string {
 		}
 		return meta.PosterURL
 	default: // poster
+		if cfg.BackdropAsPoster && meta.BackdropURL != "" {
+			// Use the backdrop center-cropped to poster dimensions.
+			// resizeFit already handles the cover-and-crop, so no extra work here.
+			return meta.BackdropURL
+		}
 		return meta.PosterURL
 	}
 }

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -315,7 +315,10 @@ func TestQualityBadgesDrawOnImage(t *testing.T) {
 	img := image.NewNRGBA(image.Rect(0, 0, 580, 859))
 	draw.Draw(img, img.Bounds(), &image.Uniform{C: color.NRGBA{255, 255, 255, 255}}, image.Point{}, draw.Src)
 
-	_ = drawQualityBadges(img, []string{"4k", "hdr", "dv"}, 1.0)
+	got := drawQualityBadges(img, []string{"4k", "hdr", "dv"}, 1.0)
+	if got == 0 {
+		t.Error("drawQualityBadges returned 0 for non-empty tokens")
+	}
 
 	// Quality badges are drawn in the top-right corner.
 	// Sample top-right quadrant for any non-white pixel.
@@ -338,8 +341,11 @@ func TestQualityBadgesNoopOnEmpty(t *testing.T) {
 	img := image.NewNRGBA(image.Rect(0, 0, 100, 150))
 	draw.Draw(img, img.Bounds(), &image.Uniform{C: color.NRGBA{255, 255, 255, 255}}, image.Point{}, draw.Src)
 	before := clonePixels(img)
-	_ = drawQualityBadges(img, nil, 1.0)
+	got := drawQualityBadges(img, nil, 1.0)
 	after := clonePixels(img)
+	if got != 0 {
+		t.Errorf("drawQualityBadges returned %d for nil tokens, want 0", got)
+	}
 	if before != after {
 		t.Error("drawQualityBadges with nil tokens must not modify the image")
 	}
@@ -414,6 +420,48 @@ func TestGenreBadgeNoopOnEmpty(t *testing.T) {
 	after := clonePixels(img)
 	if before != after {
 		t.Error("drawGenreBadge with empty genres must not modify the image")
+	}
+}
+
+// ── Scale coverage (1.5× and 3.0×) ──────────────────────────────────────────
+
+func TestOverlayFunctionsAtLargeScales(t *testing.T) {
+	for _, scale := range []float64{1.5, 3.0} {
+		scale := scale
+		t.Run(fmt.Sprintf("scale=%.1f", scale), func(t *testing.T) {
+			w := int(580 * scale)
+			h := int(859 * scale)
+
+			img := image.NewNRGBA(image.Rect(0, 0, w, h))
+			draw.Draw(img, img.Bounds(), &image.Uniform{C: color.NRGBA{255, 255, 255, 255}}, image.Point{}, draw.Src)
+
+			// drawQualityBadges: must return > 0 for non-empty tokens
+			got := drawQualityBadges(img, []string{"4k", "hdr"}, scale)
+			if got == 0 {
+				t.Errorf("drawQualityBadges returned 0 at scale %.1f", scale)
+			}
+
+			// drawAgeRatingBadge: must change pixels
+			beforeAge := clonePixels(img)
+			drawAgeRatingBadge(img, "TV-MA", "br", scale)
+			if clonePixels(img) == beforeAge {
+				t.Errorf("drawAgeRatingBadge had no effect at scale %.1f", scale)
+			}
+
+			// drawGenreBadge: must change pixels
+			beforeGenre := clonePixels(img)
+			drawGenreBadge(img, []string{"Action", "Drama"}, "bl", scale)
+			if clonePixels(img) == beforeGenre {
+				t.Errorf("drawGenreBadge had no effect at scale %.1f", scale)
+			}
+
+			// drawTrendingBadge: must change pixels
+			beforeTrend := clonePixels(img)
+			drawTrendingBadge(img, scale)
+			if clonePixels(img) == beforeTrend {
+				t.Errorf("drawTrendingBadge had no effect at scale %.1f", scale)
+			}
+		})
 	}
 }
 

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -461,6 +461,30 @@ func TestOverlayFunctionsAtLargeScales(t *testing.T) {
 			if clonePixels(img) == beforeTrend {
 				t.Errorf("drawTrendingBadge had no effect at scale %.1f", scale)
 			}
+
+			// drawProviderBadges: must change pixels
+			beforeProv := clonePixels(img)
+			drawProviderBadges(img, []provider.WatchProvider{{ID: 8, Name: "Netflix"}}, scale)
+			if clonePixels(img) == beforeProv {
+				t.Errorf("drawProviderBadges had no effect at scale %.1f", scale)
+			}
+
+			// drawAggregateBar: cfg.Size drives its internal scale factor
+			var cfgSize imageconfig.MediaSize
+			if scale >= 2.5 {
+				cfgSize = imageconfig.Size4K
+			} else {
+				cfgSize = imageconfig.SizeLarge
+			}
+			barCfg := imageconfig.Default()
+			barCfg.AggregateBar = true
+			barCfg.AggregateBarPos = "bottom"
+			barCfg.Size = cfgSize
+			beforeBar := clonePixels(img)
+			drawAggregateBar(img, []provider.Rating{{Source: "tmdb", Value: 8.0}}, barCfg)
+			if clonePixels(img) == beforeBar {
+				t.Errorf("drawAggregateBar had no effect at scale %.1f", scale)
+			}
 		})
 	}
 }

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -315,7 +315,7 @@ func TestQualityBadgesDrawOnImage(t *testing.T) {
 	img := image.NewNRGBA(image.Rect(0, 0, 580, 859))
 	draw.Draw(img, img.Bounds(), &image.Uniform{C: color.NRGBA{255, 255, 255, 255}}, image.Point{}, draw.Src)
 
-	drawQualityBadges(img, []string{"4k", "hdr", "dv"})
+	_ = drawQualityBadges(img, []string{"4k", "hdr", "dv"}, 1.0)
 
 	// Quality badges are drawn in the top-right corner.
 	// Sample top-right quadrant for any non-white pixel.
@@ -338,7 +338,7 @@ func TestQualityBadgesNoopOnEmpty(t *testing.T) {
 	img := image.NewNRGBA(image.Rect(0, 0, 100, 150))
 	draw.Draw(img, img.Bounds(), &image.Uniform{C: color.NRGBA{255, 255, 255, 255}}, image.Point{}, draw.Src)
 	before := clonePixels(img)
-	drawQualityBadges(img, nil)
+	_ = drawQualityBadges(img, nil, 1.0)
 	after := clonePixels(img)
 	if before != after {
 		t.Error("drawQualityBadges with nil tokens must not modify the image")
@@ -350,7 +350,7 @@ func TestQualityBadgesNoopOnEmpty(t *testing.T) {
 func TestAgeRatingBadgeDrawsTL(t *testing.T) {
 	img := image.NewNRGBA(image.Rect(0, 0, 580, 859))
 	draw.Draw(img, img.Bounds(), &image.Uniform{C: color.NRGBA{255, 255, 255, 255}}, image.Point{}, draw.Src)
-	drawAgeRatingBadge(img, "TV-MA", "tl")
+	drawAgeRatingBadge(img, "TV-MA", "tl", 1.0)
 
 	// Top-left corner should have non-white pixels.
 	nonWhite := 0
@@ -371,7 +371,7 @@ func TestAgeRatingBadgeNoopOnEmptyRating(t *testing.T) {
 	img := image.NewNRGBA(image.Rect(0, 0, 100, 150))
 	draw.Draw(img, img.Bounds(), &image.Uniform{C: color.NRGBA{200, 200, 200, 255}}, image.Point{}, draw.Src)
 	before := clonePixels(img)
-	drawAgeRatingBadge(img, "", "tl")
+	drawAgeRatingBadge(img, "", "tl", 1.0)
 	after := clonePixels(img)
 	if before != after {
 		t.Error("drawAgeRatingBadge with empty rating must not modify the image")
@@ -383,7 +383,7 @@ func TestAgeRatingBadgeNoopOnEmptyRating(t *testing.T) {
 func TestGenreBadgeDrawsBL(t *testing.T) {
 	img := image.NewNRGBA(image.Rect(0, 0, 580, 859))
 	draw.Draw(img, img.Bounds(), &image.Uniform{C: color.NRGBA{255, 255, 255, 255}}, image.Point{}, draw.Src)
-	drawGenreBadge(img, []string{"Action", "Drama", "Thriller"}, "bl")
+	drawGenreBadge(img, []string{"Action", "Drama", "Thriller"}, "bl", 1.0)
 
 	bounds := img.Bounds()
 	nonWhite := 0
@@ -403,14 +403,14 @@ func TestGenreBadgeDrawsBL(t *testing.T) {
 func TestGenreBadgeLimitsToThreeGenres(t *testing.T) {
 	// Just verify no panic with many genres.
 	img := image.NewNRGBA(image.Rect(0, 0, 580, 859))
-	drawGenreBadge(img, []string{"Action", "Drama", "Thriller", "Horror", "Sci-Fi"}, "bl")
+	drawGenreBadge(img, []string{"Action", "Drama", "Thriller", "Horror", "Sci-Fi"}, "bl", 1.0)
 }
 
 func TestGenreBadgeNoopOnEmpty(t *testing.T) {
 	img := image.NewNRGBA(image.Rect(0, 0, 100, 150))
 	draw.Draw(img, img.Bounds(), &image.Uniform{C: color.NRGBA{128, 128, 128, 255}}, image.Point{}, draw.Src)
 	before := clonePixels(img)
-	drawGenreBadge(img, nil, "bl")
+	drawGenreBadge(img, nil, "bl", 1.0)
 	after := clonePixels(img)
 	if before != after {
 		t.Error("drawGenreBadge with empty genres must not modify the image")
@@ -579,7 +579,7 @@ func TestAggregateBarFiltersUnselectedSources(t *testing.T) {
 func TestTrendingBadgeDrawsOnImage(t *testing.T) {
 	img := image.NewNRGBA(image.Rect(0, 0, 300, 450))
 	before := clonePixels(img)
-	drawTrendingBadge(img)
+	drawTrendingBadge(img, 1.0)
 	after := clonePixels(img)
 	if before == after {
 		t.Error("expected pixels to change after drawTrendingBadge")

--- a/internal/imageconfig/config.go
+++ b/internal/imageconfig/config.go
@@ -66,22 +66,23 @@ const (
 	LayoutLeft      RatingsLayout = "left"
 	LayoutRight     RatingsLayout = "right"
 	LayoutSplitSide RatingsLayout = "split-side"
+	LayoutNone      RatingsLayout = "none"
 )
 
 // Config is the canonical, normalized render config for a media request.
 // All fields carry explicit defaults; zero values are never used in render logic.
 type Config struct {
-	Size           MediaSize      `json:"size"`
-	ArtworkSource  ArtworkSource  `json:"artworkSource"`
-	Language       string         `json:"language"`
-	TextPreference TextPreference `json:"textPreference"`
-	Ratings        []string       `json:"ratings"`
-	RatingsLayout  RatingsLayout  `json:"ratingsLayout"`
-	BadgeStyle     BadgeStyle     `json:"badgeStyle"`
-	BadgeTheme     BadgeTheme     `json:"badgeTheme"`
-	Badges         []string       `json:"badges,omitempty"`
-	AgeRating      bool           `json:"ageRating"`
-	AgeRatingPos   string         `json:"ageRatingPos,omitempty"`
+	Size              MediaSize      `json:"size"`
+	ArtworkSource     ArtworkSource  `json:"artworkSource"`
+	Language          string         `json:"language"`
+	TextPreference    TextPreference `json:"textPreference"`
+	Ratings           []string       `json:"ratings"`
+	RatingsLayout     RatingsLayout  `json:"ratingsLayout"`
+	BadgeStyle        BadgeStyle     `json:"badgeStyle"`
+	BadgeTheme        BadgeTheme     `json:"badgeTheme"`
+	Badges            []string       `json:"badges,omitempty"`
+	AgeRating         bool           `json:"ageRating"`
+	AgeRatingPos      string         `json:"ageRatingPos,omitempty"`
 	Genre             bool           `json:"genre"`
 	GenrePos          string         `json:"genrePos,omitempty"`
 	Providers         bool           `json:"providers"`
@@ -89,6 +90,7 @@ type Config struct {
 	AggregateBar      bool           `json:"aggregateBar"`
 	AggregateBarPos   string         `json:"aggregateBarPos,omitempty"` // "top" | "bottom"
 	Trending          bool           `json:"trending"`
+	BackdropAsPoster  bool           `json:"backdropAsPoster,omitempty"`
 }
 
 // Default returns a Config populated with production defaults.
@@ -127,6 +129,7 @@ type raw struct {
 	AggregateBar     *bool    `json:"aggregateBar"`
 	AggregateBarPos  *string  `json:"aggregateBarPos"`
 	Trending         *bool    `json:"trending"`
+	BackdropAsPoster *bool    `json:"backdropAsPoster"`
 }
 
 // Parse deserializes a profile config JSON blob into a normalized Config.
@@ -220,6 +223,9 @@ func Parse(data json.RawMessage) Config {
 	if r.Trending != nil {
 		cfg.Trending = *r.Trending
 	}
+	if r.BackdropAsPoster != nil {
+		cfg.BackdropAsPoster = *r.BackdropAsPoster
+	}
 	return cfg
 }
 
@@ -247,6 +253,7 @@ func CacheKey(cfg Config) string {
 		AggregateBar     bool           `json:"aggregateBar"`
 		AggregateBarPos  string         `json:"aggregateBarPos"`
 		Trending         bool           `json:"trending"`
+		BackdropAsPoster bool           `json:"backdropAsPoster"`
 	}
 	ratings := make([]string, len(cfg.Ratings))
 	copy(ratings, cfg.Ratings)
@@ -274,6 +281,7 @@ func CacheKey(cfg Config) string {
 		AggregateBar:     cfg.AggregateBar,
 		AggregateBarPos:  cfg.AggregateBarPos,
 		Trending:         cfg.Trending,
+		BackdropAsPoster: cfg.BackdropAsPoster,
 	}
 	b, _ := json.Marshal(c)
 	sum := sha256.Sum256(b)
@@ -357,6 +365,8 @@ func normalizeRatingsLayout(v string) RatingsLayout {
 		return LayoutRight
 	case "split-side", "splittside", "split_side":
 		return LayoutSplitSide
+	case "none", "hidden", "off":
+		return LayoutNone
 	}
 	return ""
 }

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -110,6 +110,10 @@ func NewHandler(version string, store *profile.Store, settingsStore *settings.St
 			h := sha256.Sum256([]byte(configParam))
 			cfgKeyInput = cfgKeyInput + ":" + hex.EncodeToString(h[:8])
 		}
+		// Append the cache-buster value so ?cb=timestamp produces a fresh key.
+		if cb := queryValue(raw, "cb", ""); cb != "" {
+			cfgKeyInput = cfgKeyInput + ":cb=" + cb
+		}
 		cacheKey := render.CacheKey(mediaType, id, cfgKeyInput, uuid)
 		var pngBytes []byte
 		fromCache := false

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -110,9 +110,10 @@ func NewHandler(version string, store *profile.Store, settingsStore *settings.St
 			h := sha256.Sum256([]byte(configParam))
 			cfgKeyInput = cfgKeyInput + ":" + hex.EncodeToString(h[:8])
 		}
-		// Append the cache-buster value so ?cb=timestamp produces a fresh key.
+		// Hash the cache-buster so unbounded user input can't inflate the key.
 		if cb := queryValue(raw, "cb", ""); cb != "" {
-			cfgKeyInput = cfgKeyInput + ":cb=" + cb
+			hcb := sha256.Sum256([]byte(cb))
+			cfgKeyInput = cfgKeyInput + ":cb=" + hex.EncodeToString(hcb[:8])
 		}
 		cacheKey := render.CacheKey(mediaType, id, cfgKeyInput, uuid)
 		var pngBytes []byte

--- a/web/components/configurator-client.tsx
+++ b/web/components/configurator-client.tsx
@@ -87,6 +87,7 @@ export function ConfiguratorClient() {
       genre: cfg.genre, genrePos: cfg.genrePos, badges: cfg.badges,
       providers: cfg.providers, aggregateBar: cfg.aggregateBar,
       aggregateBarPos: cfg.aggregateBarPos, trending: cfg.trending,
+      backdropAsPoster: cfg.backdropAsPoster,
     }));
   }, []);
 
@@ -319,7 +320,7 @@ export function ConfiguratorClient() {
 
           {activeTab === 'display' && (
             <div id={`${uid}-panel-display`} role="tabpanel" aria-labelledby={`${uid}-tab-display`} className="tabpanel-enter">
-              <DisplayPanel uid={uid} config={config} onUpdate={updateConfig} onToggleBadge={toggleBadge} onReset={() => { markManualEdit(); setConfig(DEFAULT_CONFIG); }} />
+              <DisplayPanel uid={uid} mediaType={mediaType} config={config} onUpdate={updateConfig} onToggleBadge={toggleBadge} onReset={() => { markManualEdit(); setConfig(DEFAULT_CONFIG); }} />
             </div>
           )}
 

--- a/web/components/configurator-display.tsx
+++ b/web/components/configurator-display.tsx
@@ -84,13 +84,14 @@ function ToggleRow({ label, hint, checked, onChange }: {
 
 interface DisplayPanelProps {
   uid: string;
+  mediaType: string;
   config: ConfigState;
   onUpdate: UpdateConfigFn;
   onToggleBadge: (b: string) => void;
   onReset: () => void;
 }
 
-export function DisplayPanel({ uid, config, onUpdate, onToggleBadge, onReset }: DisplayPanelProps) {
+export function DisplayPanel({ uid, mediaType, config, onUpdate, onToggleBadge, onReset }: DisplayPanelProps) {
   return (
     <div className="panel">
       <div className="panel-body cfg-fields">
@@ -138,6 +139,15 @@ export function DisplayPanel({ uid, config, onUpdate, onToggleBadge, onReset }: 
             {TEXT_PREF_OPTIONS.map(o => <option key={o.id} value={o.id}>{o.label}</option>)}
           </select>
         </Field>
+
+        {mediaType === 'poster' && (
+          <ToggleRow
+            label="Use backdrop as poster"
+            hint="Center-crop the backdrop image instead of the standard poster"
+            checked={config.backdropAsPoster}
+            onChange={() => onUpdate('backdropAsPoster', !config.backdropAsPoster)}
+          />
+        )}
 
         <ToggleRow
           label="Age rating badge"

--- a/web/components/configurator-panels.tsx
+++ b/web/components/configurator-panels.tsx
@@ -161,7 +161,9 @@ export function RatingsPanel({ uid, config, onUpdate, onToggleRating }: RatingsP
             </div>
           ))}
           <span className="hint" style={{ marginTop: 0 }}>
-            Displayed in the order selected
+            Displayed in the order selected. Only sources that have data for
+            the specific title will appear — selecting a source does not
+            guarantee it shows up if the provider has no rating for that title.
           </span>
         </fieldset>
       </div>

--- a/web/components/configurator-types.ts
+++ b/web/components/configurator-types.ts
@@ -42,9 +42,9 @@ export const LAYOUT_OPTIONS = [
 ] as const;
 
 export const BADGE_STYLE_OPTIONS = [
-  { id: 'pill',   label: 'Pill'   },
-  { id: 'square', label: 'Square' },
-  { id: 'glass',  label: 'Glass'  },
+  { id: 'pill',   label: 'Pill'    },
+  { id: 'square', label: 'Square'  },
+  { id: 'glass',  label: 'Outline' },
 ] as const;
 
 export const BADGE_THEME_OPTIONS = [
@@ -115,6 +115,7 @@ export interface ConfigState {
   aggregateBar: boolean;
   aggregateBarPos: string;
   trending: boolean;
+  backdropAsPoster: boolean;
 }
 
 export const DEFAULT_CONFIG: ConfigState = {
@@ -135,6 +136,7 @@ export const DEFAULT_CONFIG: ConfigState = {
   aggregateBar: false,
   aggregateBarPos: 'bottom',
   trending: false,
+  backdropAsPoster: false,
 };
 
 export type UpdateConfigFn = <K extends keyof ConfigState>(key: K, value: ConfigState[K]) => void;

--- a/web/components/install-panel.tsx
+++ b/web/components/install-panel.tsx
@@ -42,7 +42,7 @@ export function InstallPanel({ configKey, onNotice }: InstallPanelProps) {
   const [selectedInstance, setSelectedInstance] = useState(PUBLIC_INSTANCES[0].url);
   const [customUrl, setCustomUrl] = useState('');
   const isCustom = selectedInstance === '__custom__';
-  const baseUrl = isCustom ? customUrl : selectedInstance;
+  const baseUrl = isCustom ? customUrl.trim() : selectedInstance;
   const isPublic = PUBLIC_URLS.has(baseUrl);
   const [userUUID, setUserUUID] = useState('');
   const [password, setPassword] = useState('');
@@ -60,7 +60,7 @@ export function InstallPanel({ configKey, onNotice }: InstallPanelProps) {
         baseUrl,
         userUUID: userUUID.trim(),
         password,
-        addonPassword: addonPassword || undefined,
+        addonPassword: !isPublic && addonPassword ? addonPassword : undefined,
         posterUrlPattern: patterns.poster,
         backgroundUrlPattern: patterns.backdrop,
         logoUrlPattern: patterns.logo,
@@ -114,6 +114,7 @@ export function InstallPanel({ configKey, onNotice }: InstallPanelProps) {
               onChange={e => setCustomUrl(e.target.value)}
               placeholder="https://your-aiom-instance.example.com"
               spellCheck={false}
+              required
               aria-label="Custom instance URL"
             />
           )}
@@ -162,7 +163,7 @@ export function InstallPanel({ configKey, onNotice }: InstallPanelProps) {
         <button
           className="btn btn-primary"
           onClick={handleInstall}
-          disabled={installing || !configKey || !userUUID.trim() || !password}
+          disabled={installing || !configKey || !userUUID.trim() || !password || (isCustom && !customUrl.trim())}
         >
           <Rocket size={14} aria-hidden />
           {installing ? 'Installing…' : 'Install to AIOMetadata'}

--- a/web/components/install-panel.tsx
+++ b/web/components/install-panel.tsx
@@ -5,6 +5,20 @@ import { Rocket, ExternalLink } from 'lucide-react';
 import { installToAIOM, renderOrigin } from '@/lib/api';
 import { CopyButton } from './copy-button';
 
+const PUBLIC_INSTANCES = [
+  { label: 'ElfHosted (elfhosted.com)',       url: 'https://aiometadata.elfhosted.com' },
+  { label: 'MidnightIgnite',                  url: 'https://aiometadatafortheweebs.midnightignite.me' },
+  { label: 'Stremio.ru (kuu)',                url: 'https://aiometadata.stremio.ru' },
+  { label: 'Viren070',                        url: 'https://aiometadata.viren070.me' },
+  { label: 'ForTheWeak',                      url: 'https://aiometadata.fortheweak.cloud' },
+  { label: 'ForTheWeak (nhyira.dev)',         url: 'https://aiometadatafortheweak.nhyira.dev' },
+  { label: 'Omni (12312023)',                 url: 'https://aiometadata.12312023.xyz' },
+  { label: 'ATBP Hosting',                    url: 'https://aiomd.atbphosting.com' },
+  { label: 'ForTheWizards (wizaardd)',        url: 'https://aiometadata.forthewizards.uk' },
+];
+
+const PUBLIC_URLS = new Set(PUBLIC_INSTANCES.map(i => i.url));
+
 /** Artwork URL patterns for AIOMetadata's custom-art fields. */
 export function aiomPatterns(configKey: string) {
   const origin = renderOrigin();
@@ -25,7 +39,11 @@ interface InstallPanelProps {
 
 export function InstallPanel({ configKey, onNotice }: InstallPanelProps) {
   const uid = useId();
-  const [baseUrl, setBaseUrl] = useState('');
+  const [selectedInstance, setSelectedInstance] = useState(PUBLIC_INSTANCES[0].url);
+  const [customUrl, setCustomUrl] = useState('');
+  const isCustom = selectedInstance === '__custom__';
+  const baseUrl = isCustom ? customUrl : selectedInstance;
+  const isPublic = PUBLIC_URLS.has(baseUrl);
   const [userUUID, setUserUUID] = useState('');
   const [password, setPassword] = useState('');
   const [addonPassword, setAddonPassword] = useState('');
@@ -77,15 +95,28 @@ export function InstallPanel({ configKey, onNotice }: InstallPanelProps) {
 
         <div className="field">
           <label className="label" htmlFor={`${uid}-base`}>Instance</label>
-          <input
+          <select
             id={`${uid}-base`}
-            className="input"
-            value={baseUrl}
-            onChange={e => setBaseUrl(e.target.value)}
-            placeholder="https://aiometadata.elfhosted.com"
-            spellCheck={false}
-          />
-          <span className="hint">Leave empty for the ElfHosted public instance</span>
+            className="select"
+            value={selectedInstance}
+            onChange={e => setSelectedInstance(e.target.value)}
+          >
+            {PUBLIC_INSTANCES.map(i => (
+              <option key={i.url} value={i.url}>{i.label}</option>
+            ))}
+            <option value="__custom__">Custom URL…</option>
+          </select>
+          {isCustom && (
+            <input
+              className="input"
+              style={{ marginTop: 'var(--sp-2)' }}
+              value={customUrl}
+              onChange={e => setCustomUrl(e.target.value)}
+              placeholder="https://your-aiom-instance.example.com"
+              spellCheck={false}
+              aria-label="Custom instance URL"
+            />
+          )}
         </div>
 
         <div className="field">
@@ -113,18 +144,20 @@ export function InstallPanel({ configKey, onNotice }: InstallPanelProps) {
           />
         </div>
 
-        <div className="field">
-          <label className="label" htmlFor={`${uid}-apw`}>Addon password (self-hosted only)</label>
-          <input
-            id={`${uid}-apw`}
-            className="input"
-            type="password"
-            value={addonPassword}
-            onChange={e => setAddonPassword(e.target.value)}
-            autoComplete="off"
-          />
-          <span className="hint">Only needed when your instance sets ADDON_PASSWORD</span>
-        </div>
+        {!isPublic && (
+          <div className="field">
+            <label className="label" htmlFor={`${uid}-apw`}>Addon password</label>
+            <input
+              id={`${uid}-apw`}
+              className="input"
+              type="password"
+              value={addonPassword}
+              onChange={e => setAddonPassword(e.target.value)}
+              autoComplete="off"
+            />
+            <span className="hint">Only needed when your instance sets ADDON_PASSWORD</span>
+          </div>
+        )}
 
         <button
           className="btn btn-primary"

--- a/web/components/install-panel.tsx
+++ b/web/components/install-panel.tsx
@@ -17,7 +17,16 @@ const PUBLIC_INSTANCES = [
   { label: 'ForTheWizards (wizaardd)',        url: 'https://aiometadata.forthewizards.uk' },
 ];
 
-const PUBLIC_URLS = new Set(PUBLIC_INSTANCES.map(i => i.url));
+function normaliseOrigin(raw: string): string {
+  try {
+    const u = new URL(raw);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return raw;
+  }
+}
+
+const PUBLIC_URLS = new Set(PUBLIC_INSTANCES.map(i => normaliseOrigin(i.url)));
 
 /** Artwork URL patterns for AIOMetadata's custom-art fields. */
 export function aiomPatterns(configKey: string) {
@@ -43,7 +52,7 @@ export function InstallPanel({ configKey, onNotice }: InstallPanelProps) {
   const [customUrl, setCustomUrl] = useState('');
   const isCustom = selectedInstance === '__custom__';
   const baseUrl = isCustom ? customUrl.trim() : selectedInstance;
-  const isPublic = PUBLIC_URLS.has(baseUrl);
+  const isPublic = PUBLIC_URLS.has(normaliseOrigin(baseUrl));
   const [userUUID, setUserUUID] = useState('');
   const [password, setPassword] = useState('');
   const [addonPassword, setAddonPassword] = useState('');


### PR DESCRIPTION
## Summary

- **Badge scaling**: All overlay functions (`drawQualityBadges`, `drawAgeRatingBadge`, `drawGenreBadge`, `drawProviderBadges`, `drawTrendingBadge`, `drawAggregateBar`) now accept a `scale float64` parameter derived from `outputScale(cfg.Size)`, so text and badges render proportionally larger at Large (1.5×) and 4K (3×) outputs. A new `labelFaceFor(scale)` mirrors `valueFaceFor` for label-weight text.
- **Hidden layout (LayoutNone)**: `drawBadgesInPlace` now returns immediately when `cfg.RatingsLayout == LayoutNone`. `normalizeRatingsLayout` maps `"none"/"hidden"/"off"` to this value. Frontend already had `none` in the layout options.
- **Split sides layout**: Implemented `drawBadgesSplitSide` — first half of badges stacked vertically on the left edge, second half on the right, both vertically centered.
- **Badge style distinction**: `BadgeGlass` is now a true outline style (zero-alpha fill, solid white border), visually distinct from `BadgePill` (solid capsule fill). Frontend label updated from "Glass" → "Outline".
- **Corner collision**: Age rating `"inherit"` default changed from `tl` → `br`, resolving the overlap with the trending badge (TL) and quality badges (TR).
- **Cache buster**: `handler.go` reads `?cb=` query param and appends it to `cfgKeyInput`, so cache-busted URLs produce a distinct render cache key.
- **Backdrop as poster**: `BackdropAsPoster bool` added to `Config`. When set and `mediaType == "poster"`, `selectArtworkURL` returns `meta.BackdropURL` instead; `resizeFit` center-crops it to poster dimensions automatically. Frontend toggle shown only on the poster tab.
- **AIOM install panel**: Instance URL replaced with a `<select>` of 9 public AIOM instances + "Custom" option. Addon password field is hidden for public instances and visible only when a custom URL is entered.
- **Ratings hint**: Explains to users that sources only appear when the provider actually has rating data for that specific title.

## Test plan

- [ ] Go: `go build ./...` passes (verified)
- [ ] TypeScript: `npx tsc --noEmit` passes (verified)
- [ ] Render a poster at Normal/Large/4K — confirm all badges scale visibly
- [ ] Set layout to "Hidden" — confirm no rating badges appear
- [ ] Set layout to "Split sides" — confirm first half of selected ratings on left, rest on right
- [ ] Enable Trending + Age Rating — confirm no corner overlap (age rating should be BR by default)
- [ ] Add `?cb=123` to a render URL — confirm a second request with `?cb=456` fetches a fresh image
- [ ] Enable "Use backdrop as poster" — confirm backdrop image is used for poster type
- [ ] AIOM install panel: verify dropdown lists 9 public instances; addon password hidden for public, visible for Custom