### PR TITLE
feat: composite TMDB provider logos in streaming badge row

### DIFF
--- a/internal/compose/badge.go
+++ b/internal/compose/badge.go
@@ -414,6 +414,12 @@ func drawBadgesSplitSide(out *image.NRGBA, specs []badgeSpec, innerH, rowGap, ed
 	minY := bounds.Min.Y + edgeY
 	maxYLeft := bounds.Max.Y - edgeY - leftH
 	maxYRight := bounds.Max.Y - edgeY - rightH
+	if maxYLeft < minY {
+		maxYLeft = minY
+	}
+	if maxYRight < minY {
+		maxYRight = minY
+	}
 
 	y := midY - leftH/2
 	if y < minY {

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -464,7 +464,7 @@ func TestOverlayFunctionsAtLargeScales(t *testing.T) {
 
 			// drawProviderBadges: must change pixels
 			beforeProv := clonePixels(img)
-			drawProviderBadges(img, []provider.WatchProvider{{ID: 8, Name: "Netflix"}}, scale)
+			drawProviderBadges(img, []provider.WatchProvider{{ID: 8, Name: "Netflix"}}, scale, 0)
 			if clonePixels(img) == beforeProv {
 				t.Errorf("drawProviderBadges had no effect at scale %.1f", scale)
 			}

--- a/web/components/install-panel.tsx
+++ b/web/components/install-panel.tsx
@@ -26,7 +26,10 @@ function normaliseOrigin(raw: string): string {
 }
 
 function isValidUrl(raw: string): boolean {
-  try { new URL(raw); return true; } catch { return false; }
+  try {
+    const u = new URL(raw);
+    return u.protocol === 'http:' || u.protocol === 'https:';
+  } catch { return false; }
 }
 
 const PUBLIC_URLS = new Set(PUBLIC_INSTANCES.map(i => normaliseOrigin(i.url)));


### PR DESCRIPTION
## Summary

- Adds `LogoPath string` to `WatchProvider` (additive, non-breaking)
- Parses `logo_path` from TMDB watch/providers API for flatrate and rent entries
- New `logo_fetch.go`: HTTP fetcher with `sync.Map` cache, 3 s timeout, JPEG/PNG decode, NRGBA conversion
- `drawProviderBadges` composites a square logo icon when the TMDB logo is available; gracefully falls back to the existing text-on-brand-colour chip when the fetch fails or returns no logo
- `drawLogoScaled`: nearest-neighbour scale + straight-alpha blend into the badge rectangle

## Behaviour

Provider badges now show the actual service logo (Netflix N, Prime arrow, Disney+ D, etc.) instead of short text strings. The badge size and position are unchanged. Logos are fetched once per process and cached indefinitely.

## Test plan

- [ ] `go build ./...` — passes
- [ ] `go test ./internal/compose/...` — 24 tests pass
- [ ] Live: enable "Where to watch" in the configurator and preview a popular title — provider badge row should show logos
- [ ] Disable network / use a title with no providers — should render cleanly with no panic