### PR TITLE
fix(compose): backdrop poster auto-shows logo; HDR dedup; badge polish

### DIFF
--- a/internal/compose/backdrop.go
+++ b/internal/compose/backdrop.go
@@ -129,12 +129,49 @@ func resizeFitSmart(src image.Image, maxW, maxH int) image.Image {
 	return dst
 }
 
+// resizeContain scales src to fit entirely within maxW×maxH (letterbox / pillarbox)
+// using bilinear interpolation. Unlike resizeFit, it never crops — transparent
+// pixels fill any gap so the full source image is always visible.
+func resizeContain(src image.Image, maxW, maxH int) image.Image {
+	srcB := src.Bounds()
+	srcW, srcH := srcB.Dx(), srcB.Dy()
+	if srcW == 0 || srcH == 0 {
+		return image.NewNRGBA(image.Rect(0, 0, maxW, maxH))
+	}
+
+	scaleX := float64(maxW) / float64(srcW)
+	scaleY := float64(maxH) / float64(srcH)
+	scale := scaleX
+	if scaleY < scale {
+		scale = scaleY
+	}
+
+	scaledW := int(float64(srcW)*scale + 0.5)
+	scaledH := int(float64(srcH)*scale + 0.5)
+	if scaledW < 1 {
+		scaledW = 1
+	}
+	if scaledH < 1 {
+		scaledH = 1
+	}
+
+	dst := image.NewNRGBA(image.Rect(0, 0, maxW, maxH))
+	scaled := image.NewNRGBA(image.Rect(0, 0, scaledW, scaledH))
+	xdraw.BiLinear.Scale(scaled, scaled.Bounds(), src, srcB, xdraw.Over, nil)
+
+	offX := (maxW - scaledW) / 2
+	offY := (maxH - scaledH) / 2
+	draw.Draw(dst, image.Rect(offX, offY, offX+scaledW, offY+scaledH), scaled, image.Point{}, draw.Src)
+	return dst
+}
+
 // drawBackdropLogoOverlay composites a title logo image onto base. The logo is
 // scaled to fit within 65% of the base width and 20% of the base height, then
-// centred horizontally and placed in the lower-third (72% from top). A
-// semi-transparent gradient scrim is drawn behind the logo so it remains
-// legible over bright backdrops.
-func drawBackdropLogoOverlay(base *image.NRGBA, logoData []byte) {
+// centred horizontally and placed clear of the bottom-reserved area (ratings
+// strip + provider chips). A semi-transparent gradient scrim is drawn behind
+// the logo so it remains legible over bright backdrops.
+// ratingsH is the pixel height consumed by the ratings strip at the bottom.
+func drawBackdropLogoOverlay(base *image.NRGBA, logoData []byte, ratingsH int) {
 	if len(logoData) == 0 {
 		return
 	}
@@ -172,12 +209,22 @@ func drawBackdropLogoOverlay(base *image.NRGBA, logoData []byte) {
 	xdraw.CatmullRom.Scale(scaled, scaled.Bounds(), logoImg, lB, xdraw.Over, nil)
 
 	x := (baseW - dstW) / 2
-	logoTopY := int(float64(baseH)*0.72) - dstH/2
+
+	// Reserve space for the bottom overlay strip (ratings + provider chips).
+	// Add an extra 16px gap so the logo scrim never grazes the chip row.
+	bottomReserved := ratingsH + 16
+	usableH := baseH - bottomReserved
+	if usableH < dstH {
+		usableH = dstH
+	}
+
+	// Centre the logo in the lower-third of the usable area (≈68% from top).
+	logoTopY := int(float64(usableH)*0.68) - dstH/2
 	if logoTopY < 0 {
 		logoTopY = 0
 	}
-	if logoTopY+dstH > baseH {
-		logoTopY = baseH - dstH
+	if logoTopY+dstH > usableH {
+		logoTopY = usableH - dstH
 	}
 
 	// Vertical gradient scrim behind the logo for legibility over bright areas.

--- a/internal/compose/badge_overlay.go
+++ b/internal/compose/badge_overlay.go
@@ -582,7 +582,15 @@ func drawTrendingBadge(base *image.NRGBA, scale float64) {
 					continue
 				}
 			}
-			base.SetNRGBA(px, py, sheenC)
+			dp := base.NRGBAAt(px, py)
+			a := uint32(sheenC.A)
+			ia := 255 - a
+			base.SetNRGBA(px, py, color.NRGBA{
+				R: uint8((uint32(sheenC.R)*a + uint32(dp.R)*ia) / 255),
+				G: uint8((uint32(sheenC.G)*a + uint32(dp.G)*ia) / 255),
+				B: uint8((uint32(sheenC.B)*a + uint32(dp.B)*ia) / 255),
+				A: uint8((a*255 + uint32(dp.A)*ia) / 255),
+			})
 		}
 	}
 

--- a/internal/compose/badge_overlay.go
+++ b/internal/compose/badge_overlay.go
@@ -55,12 +55,52 @@ func qualityBadgeLabel(token string) string {
 	}
 }
 
+// hdrHierarchy lists badge tokens that are implied by a superior token.
+// When the superior is present, the implied badges are removed to avoid
+// redundant stacking (e.g. HDR10+ already implies HDR10 and HDR).
+var hdrHierarchy = []struct {
+	superior string
+	drops    []string
+}{
+	{"dv", []string{"hdr10plus", "hdr10", "hdr"}},
+	{"hdr10plus", []string{"hdr10", "hdr"}},
+	{"hdr10", []string{"hdr"}},
+}
+
+// dedupeQualityTokens removes badges that are implied by a higher-tier badge
+// already in the list.
+func dedupeQualityTokens(tokens []string) []string {
+	present := make(map[string]bool, len(tokens))
+	for _, t := range tokens {
+		present[strings.ToLower(t)] = true
+	}
+	drop := make(map[string]bool)
+	for _, rule := range hdrHierarchy {
+		if present[rule.superior] {
+			for _, d := range rule.drops {
+				drop[d] = true
+			}
+		}
+	}
+	if len(drop) == 0 {
+		return tokens
+	}
+	out := make([]string, 0, len(tokens))
+	for _, t := range tokens {
+		if !drop[strings.ToLower(t)] {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
 // drawQualityBadges renders quality/format badges (4K, HDR, DV, …) stacked
 // in the top-right corner. Returns the total pixel height consumed.
 func drawQualityBadges(base *image.NRGBA, tokens []string, scale float64) int {
 	if len(tokens) == 0 {
 		return 0
 	}
+	tokens = dedupeQualityTokens(tokens)
 	ensureFaces()
 	face := labelFaceFor(scale)
 	if face == nil {
@@ -68,12 +108,12 @@ func drawQualityBadges(base *image.NRGBA, tokens []string, scale float64) int {
 	}
 
 	s := func(v float64) int { return int(v*scale + 0.5) }
-	padX := s(6)
-	padY := s(4)
+	padX := s(8)
+	padY := s(5)
 	badgeGap := s(4)
 	edgeX := s(10)
 	edgeY := s(10)
-	radius := s(3)
+	radius := s(4)
 
 	lm := face.Metrics()
 	lAscent := lm.Ascent.Ceil()
@@ -230,12 +270,12 @@ func drawProviderBadges(base *image.NRGBA, providers []provider.WatchProvider, s
 	}
 
 	s := func(v float64) int { return int(v*scale + 0.5) }
-	padX := s(6)
-	padY := s(3)
-	badgeGap := s(5)
+	padX := s(7)
+	padY := s(4)
+	badgeGap := s(6)
 	edgeX := s(10)
-	edgeY := ratingsH + s(10) // gap above ratings strip (or above bottom edge)
-	radius := s(3)
+	edgeY := ratingsH + s(18) // extra clearance above ratings / poster title text
+	radius := s(4)
 
 	fm := face.Metrics()
 	ascent := fm.Ascent.Ceil()
@@ -492,7 +532,8 @@ func drawAggregateBar(base *image.NRGBA, ratings []provider.Rating, cfg imagecon
 
 // ── Trending badge ────────────────────────────────────────────────────────────
 
-// drawTrendingBadge draws a "TRENDING" label badge at the top-left corner.
+// drawTrendingBadge draws a "↑ TRENDING" pill badge at the top-left corner.
+// It uses a capsule shape with a subtle gradient effect via two layered fills.
 func drawTrendingBadge(base *image.NRGBA, scale float64) {
 	ensureFaces()
 	face := labelFaceFor(scale)
@@ -500,26 +541,35 @@ func drawTrendingBadge(base *image.NRGBA, scale float64) {
 		return
 	}
 
-	const label = "TRENDING"
+	const label = "↑ TRENDING"
 
 	s := func(v float64) int { return int(v*scale + 0.5) }
-	padX := s(7)
+	padX := s(9)
 	padY := s(4)
 	edgeX := s(8)
 	edgeY := s(8)
-	radius := s(3)
 
 	fm := face.Metrics()
 	ascent := fm.Ascent.Ceil()
 	descent := fm.Descent.Ceil()
 	bh := padY*2 + ascent + descent
 	bw := padX*2 + textWidth(face, label)
+	radius := bh / 2 // full capsule
 
 	bounds := base.Bounds()
 	x := bounds.Min.X + edgeX
 	y := bounds.Min.Y + edgeY
+	rect := image.Rect(x, y, x+bw, y+bh)
 
-	bg := color.NRGBA{R: 231, G: 76, B: 60, A: 230}
-	fillRoundedRect(base, image.Rect(x, y, x+bw, y+bh), radius, bg)
+	// Shadow layer for depth.
+	shadowRect := image.Rect(x+1, y+1, x+bw+1, y+bh+1)
+	fillRoundedRect(base, shadowRect, radius, color.NRGBA{R: 0, G: 0, B: 0, A: 80})
+
+	// Main fill: vivid red-orange gradient approximated by two fills.
+	fillRoundedRect(base, rect, radius, color.NRGBA{R: 220, G: 50, B: 40, A: 245})
+	// Lighter top half for a subtle sheen.
+	topHalf := image.Rect(x, y, x+bw, y+bh/2)
+	fillRoundedRect(base, topHalf, radius, color.NRGBA{R: 255, G: 80, B: 60, A: 60})
+
 	drawText(base, face, x+padX, y+padY+ascent, color.NRGBA{R: 255, G: 255, B: 255, A: 255}, label)
 }

--- a/internal/compose/badge_overlay.go
+++ b/internal/compose/badge_overlay.go
@@ -567,9 +567,24 @@ func drawTrendingBadge(base *image.NRGBA, scale float64) {
 
 	// Main fill: vivid red-orange gradient approximated by two fills.
 	fillRoundedRect(base, rect, radius, color.NRGBA{R: 220, G: 50, B: 40, A: 245})
-	// Lighter top half for a subtle sheen.
-	topHalf := image.Rect(x, y, x+bw, y+bh/2)
-	fillRoundedRect(base, topHalf, radius, color.NRGBA{R: 255, G: 80, B: 60, A: 60})
+	// Lighter top-half sheen. We clip to the badge's own corner circles (using
+	// rect + radius) rather than rounding topHalf's corners, which would create
+	// a visible curved line at the midpoint ("double bubble" artefact).
+	sheenC := color.NRGBA{R: 255, G: 80, B: 60, A: 60}
+	cr2 := float64(radius) * float64(radius)
+	for py := y; py < y+bh/2; py++ {
+		for px := x; px < x+bw; px++ {
+			if inCornerZone(px, py, rect, radius) {
+				cx, cy := cornerCenter(px, py, rect, radius)
+				ddx := float64(px) - cx + 0.5
+				ddy := float64(py) - cy + 0.5
+				if ddx*ddx+ddy*ddy > cr2 {
+					continue
+				}
+			}
+			base.SetNRGBA(px, py, sheenC)
+		}
+	}
 
 	drawText(base, face, x+padX, y+padY+ascent, color.NRGBA{R: 255, G: 255, B: 255, A: 255}, label)
 }

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -174,8 +174,12 @@ func (p *Pipeline) Render(ctx context.Context, req Request) (*Result, error) {
 	// Show the logo overlay when explicitly requested OR when the user has
 	// chosen to use the backdrop as a poster (backdrop images don't carry
 	// baked-in title text, so the overlay is the only way to show the title).
+	// Auto-enable the logo overlay only when an actual backdrop is in use.
+	// If BackdropURL is empty the pipeline falls back to poster artwork (which
+	// already carries baked-in title text), so adding a logo overlay there would
+	// double-stamp the title.
 	wantsLogoOverlay := req.Config.BackdropLogo ||
-		(req.MediaType == "poster" && req.Config.BackdropAsPoster)
+		(req.MediaType == "poster" && req.Config.BackdropAsPoster && meta.BackdropURL != "")
 	if wantsLogoOverlay && meta.LogoURL != "" {
 		if logoBytes, err := p.fetcher.Fetch(ctx, meta.LogoURL); err == nil {
 			drawBackdropLogoOverlay(composed, logoBytes, ratingsH)

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -131,9 +131,14 @@ func (p *Pipeline) Render(ctx context.Context, req Request) (*Result, error) {
 		(req.MediaType == "poster" && req.Config.BackdropAsPoster) ||
 		req.MediaType == "thumbnail"
 	var resized image.Image
-	if usesBackdrop {
+	switch {
+	case usesBackdrop:
 		resized = resizeFitSmart(srcImg, dim.Width, dim.Height)
-	} else {
+	case req.MediaType == "logo":
+		// Logo images should be letterboxed, not cover-cropped, so the
+		// title text is never clipped at the edges.
+		resized = resizeContain(srcImg, dim.Width, dim.Height)
+	default:
 		resized = resizeFit(srcImg, dim.Width, dim.Height)
 	}
 
@@ -166,9 +171,14 @@ func (p *Pipeline) Render(ctx context.Context, req Request) (*Result, error) {
 	if req.Config.Trending {
 		drawTrendingBadge(composed, scale)
 	}
-	if req.Config.BackdropLogo && usesBackdrop && meta.LogoURL != "" {
+	// Show the logo overlay when explicitly requested OR when the user has
+	// chosen to use the backdrop as a poster (backdrop images don't carry
+	// baked-in title text, so the overlay is the only way to show the title).
+	wantsLogoOverlay := req.Config.BackdropLogo ||
+		(req.MediaType == "poster" && req.Config.BackdropAsPoster)
+	if wantsLogoOverlay && meta.LogoURL != "" {
 		if logoBytes, err := p.fetcher.Fetch(ctx, meta.LogoURL); err == nil {
-			drawBackdropLogoOverlay(composed, logoBytes)
+			drawBackdropLogoOverlay(composed, logoBytes, ratingsH)
 		}
 	}
 

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -710,6 +710,42 @@ func TestBackdropAsPosterAutoEnablesLogoOverlay(t *testing.T) {
 	}
 }
 
+func TestBackdropAsPosterNoLogoWhenBackdropURLEmpty(t *testing.T) {
+	// When BackdropAsPoster is true but BackdropURL is empty (provider has no
+	// backdrop), the pipeline falls back to poster artwork. The logo overlay must
+	// NOT fire in that case to avoid double-stamping a poster's baked-in title.
+	logoFetched := false
+	fetcher := &recordingFetcher{
+		data: makeTestPNG(300, 450, color.NRGBA{50, 50, 80, 255}),
+		onFetch: func(url string) {
+			if url == "http://fake/logo.png" {
+				logoFetched = true
+			}
+		},
+	}
+	stub := &provider.StubProvider{
+		ProviderName: "tmdb",
+		Meta: &provider.MediaMeta{
+			PosterURL:   "http://fake/poster.jpg",
+			BackdropURL: "", // no backdrop available
+			LogoURL:     "http://fake/logo.png",
+		},
+	}
+	p := &Pipeline{providers: testRegistry(stub), fetcher: fetcher}
+
+	cfg := imageconfig.Default()
+	cfg.BackdropAsPoster = true
+	cfg.BackdropLogo = false
+	req := Request{MediaType: "poster", MediaID: "tt1", Config: cfg}
+
+	if _, err := p.Render(context.Background(), req); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if logoFetched {
+		t.Error("logo overlay must not fire when BackdropURL is empty (poster fallback)")
+	}
+}
+
 // recordingFetcher wraps a stubImageFetcher and calls onFetch for each URL.
 type recordingFetcher struct {
 	data    []byte

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -672,3 +672,99 @@ func TestAnimeProviderAccentColors(t *testing.T) {
 		}
 	}
 }
+
+// ── Backdrop logo auto-enable ─────────────────────────────────────────────────
+
+func TestBackdropAsPosterAutoEnablesLogoOverlay(t *testing.T) {
+	// When BackdropAsPoster is true, Render should attempt to fetch the logo
+	// URL from meta (even when BackdropLogo is false).
+	logoFetched := false
+	fetcher := &recordingFetcher{
+		data: makeTestPNG(300, 450, color.NRGBA{50, 50, 80, 255}),
+		onFetch: func(url string) {
+			if url == "http://fake/logo.png" {
+				logoFetched = true
+			}
+		},
+	}
+	stub := &provider.StubProvider{
+		ProviderName: "tmdb",
+		Meta: &provider.MediaMeta{
+			PosterURL:  "http://fake/poster.jpg",
+			BackdropURL: "http://fake/backdrop.jpg",
+			LogoURL:    "http://fake/logo.png",
+		},
+	}
+	p := &Pipeline{providers: testRegistry(stub), fetcher: fetcher}
+
+	cfg := imageconfig.Default()
+	cfg.BackdropAsPoster = true
+	cfg.BackdropLogo = false // must still trigger logo fetch
+	req := Request{MediaType: "poster", MediaID: "tt1", Config: cfg}
+
+	if _, err := p.Render(context.Background(), req); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !logoFetched {
+		t.Error("expected logo fetch when BackdropAsPoster=true, got none")
+	}
+}
+
+// recordingFetcher wraps a stubImageFetcher and calls onFetch for each URL.
+type recordingFetcher struct {
+	data    []byte
+	onFetch func(string)
+}
+
+func (r *recordingFetcher) Fetch(_ context.Context, url string) ([]byte, error) {
+	if r.onFetch != nil {
+		r.onFetch(url)
+	}
+	return r.data, nil
+}
+
+// ── HDR hierarchy deduplication ───────────────────────────────────────────────
+
+func TestDedupeQualityTokensHDRHierarchy(t *testing.T) {
+	cases := []struct {
+		in   []string
+		want []string
+	}{
+		{[]string{"hdr10plus", "hdr10", "hdr"}, []string{"hdr10plus"}},
+		{[]string{"4k", "hdr10", "hdr"}, []string{"4k", "hdr10"}},
+		{[]string{"dv", "hdr10plus", "hdr10", "hdr", "atmos"}, []string{"dv", "atmos"}},
+		{[]string{"4k", "atmos", "imax"}, []string{"4k", "atmos", "imax"}},
+		{[]string{"hdr"}, []string{"hdr"}},
+	}
+	for _, tc := range cases {
+		got := dedupeQualityTokens(tc.in)
+		if len(got) != len(tc.want) {
+			t.Errorf("dedupeQualityTokens(%v): got %v, want %v", tc.in, got, tc.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("dedupeQualityTokens(%v)[%d]: got %q, want %q", tc.in, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+// ── resizeContain ─────────────────────────────────────────────────────────────
+
+func TestResizeContainNeverExceedsBounds(t *testing.T) {
+	cases := []struct{ sw, sh, mw, mh int }{
+		{1000, 200, 500, 125},  // wider source → letterboxed
+		{200, 1000, 500, 125},  // taller source → pillarboxed
+		{400, 100, 500, 125},   // same aspect
+	}
+	for _, tc := range cases {
+		src := image.NewNRGBA(image.Rect(0, 0, tc.sw, tc.sh))
+		out := resizeContain(src, tc.mw, tc.mh)
+		b := out.Bounds()
+		if b.Dx() != tc.mw || b.Dy() != tc.mh {
+			t.Errorf("resizeContain(%dx%d → %dx%d): got canvas %dx%d",
+				tc.sw, tc.sh, tc.mw, tc.mh, b.Dx(), b.Dy())
+		}
+	}
+}

--- a/scripts/visual-test.sh
+++ b/scripts/visual-test.sh
@@ -28,9 +28,24 @@ else
   echo "warning: no .env — images may render as placeholders (no API keys)" >&2
 fi
 
-# Kill any lingering server on the test port.
+# Kill any lingering server on the test port — but only if it looks like this
+# project's API server. Refuse to kill unrelated processes that happen to be
+# using the same port, and tell the user to pick a different one instead.
 pid="$(lsof -nP -t -iTCP:"$PORT" -sTCP:LISTEN 2>/dev/null || true)"
-[ -n "$pid" ] && kill "$pid" 2>/dev/null && sleep 1 || true
+if [ -n "$pid" ]; then
+  cmd="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+  case "$cmd" in
+    *"./cmd/api"*|*"xrdb-api"*|*"go run"*"cmd/api"*)
+      kill "$pid" 2>/dev/null || true
+      sleep 1
+      ;;
+    *)
+      echo "error: port $PORT is already in use by an unrelated process (pid $pid: $cmd)." >&2
+      echo "Choose another port: ./scripts/visual-test.sh <port>" >&2
+      exit 1
+      ;;
+  esac
+fi
 
 cleanup() { [ -n "${API_PID:-}" ] && kill "$API_PID" 2>/dev/null || true; }
 trap cleanup EXIT INT TERM
@@ -62,22 +77,46 @@ EOF
 }
 
 echo "Rendering test images …"
+failures=0
 
 # 1. Backdrop-as-poster with logo overlay — The Dark Knight (tt0468569)
-curl -sf "${BASE}/poster/tt0468569?config=$(encode "$BACKDROP_LOGO")" -o "$OUT/1-backdrop-logo-batman.png" && echo "  1/4 backdrop+logo (Batman)" || echo "  1/4 FAILED"
+if curl -sf "${BASE}/poster/tt0468569?config=$(encode "$BACKDROP_LOGO")" -o "$OUT/1-backdrop-logo-batman.png"; then
+  echo "  1/4 backdrop+logo (Batman)"
+else
+  echo "  1/4 FAILED" >&2; failures=$((failures+1))
+fi
 
 # 2. Logo letterbox — The Dark Knight
-curl -sf "${BASE}/logo/tt0468569" -o "$OUT/2-logo-letterbox-batman.png" && echo "  2/4 logo letterbox (Batman)" || echo "  2/4 FAILED"
+if curl -sf "${BASE}/logo/tt0468569" -o "$OUT/2-logo-letterbox-batman.png"; then
+  echo "  2/4 logo letterbox (Batman)"
+else
+  echo "  2/4 FAILED" >&2; failures=$((failures+1))
+fi
 
 # 3. Standard poster — The Shawshank Redemption (tt0111161)
-curl -sf "${BASE}/poster/tt0111161?config=$(encode "$STANDARD")" -o "$OUT/3-standard-poster-shawshank.png" && echo "  3/4 standard poster (Shawshank)" || echo "  3/4 FAILED"
+if curl -sf "${BASE}/poster/tt0111161?config=$(encode "$STANDARD")" -o "$OUT/3-standard-poster-shawshank.png"; then
+  echo "  3/4 standard poster (Shawshank)"
+else
+  echo "  3/4 FAILED" >&2; failures=$((failures+1))
+fi
 
 # 4. Backdrop+logo+providers — Shawshank
-curl -sf "${BASE}/poster/tt0111161?config=$(encode "$WITH_PROVIDERS")" -o "$OUT/4-backdrop-logo-providers-shawshank.png" && echo "  4/4 backdrop+providers (Shawshank)" || echo "  4/4 FAILED"
+if curl -sf "${BASE}/poster/tt0111161?config=$(encode "$WITH_PROVIDERS")" -o "$OUT/4-backdrop-logo-providers-shawshank.png"; then
+  echo "  4/4 backdrop+providers (Shawshank)"
+else
+  echo "  4/4 FAILED" >&2; failures=$((failures+1))
+fi
+
+if [ "$failures" -gt 0 ]; then
+  echo "error: $failures render case(s) failed — check /tmp/xrdb-visual-test-server.log" >&2
+  exit 1
+fi
 
 echo ""
 echo "Images saved to $OUT/"
-ls -lh "$OUT/"*.png 2>/dev/null | awk '{print "  " $5 "  " $9}'
+find "$OUT" -maxdepth 1 -name '*.png' | sort | while read -r f; do
+  printf "  %s  %s\n" "$(wc -c < "$f" | awk '{printf "%.1fK", $1/1024}')" "$f"
+done
 
 # Open on macOS, display on Linux.
 if command -v open >/dev/null 2>&1; then

--- a/scripts/visual-test.sh
+++ b/scripts/visual-test.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+# Visual regression test for internal/compose changes.
+# Starts the Go API server locally, renders 4 known-good titles across the
+# main code paths (poster, backdrop-as-poster+logo, logo letterbox, provider
+# chips), saves PNGs to /tmp/xrdb-visual-test/, then opens them.
+#
+# Usage: ./scripts/visual-test.sh [port]
+# Default port: 8788 (avoids conflicts with the full dev stack on 8787)
+#
+# After the images open, inspect them:
+#   • backdrop-as-poster-logo: title logo MUST be overlaid on the backdrop
+#   • logo-letterbox: full logo visible, not cropped (transparent padding OK)
+#   • standard-poster: normal poster with rating badges
+#   • providers: provider chips visible above the badge row
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+PORT="${1:-8788}"
+OUT="/tmp/xrdb-visual-test"
+mkdir -p "$OUT"
+
+# Load .env if present (provider API keys).
+if [ -f .env ]; then
+  set -a; . ./.env; set +a
+else
+  echo "warning: no .env — images may render as placeholders (no API keys)" >&2
+fi
+
+# Kill any lingering server on the test port.
+pid="$(lsof -nP -t -iTCP:"$PORT" -sTCP:LISTEN 2>/dev/null || true)"
+[ -n "$pid" ] && kill "$pid" 2>/dev/null && sleep 1 || true
+
+cleanup() { [ -n "${API_PID:-}" ] && kill "$API_PID" 2>/dev/null || true; }
+trap cleanup EXIT INT TERM
+
+XRDB_ADDR=":$PORT" go run ./cmd/api >/tmp/xrdb-visual-test-server.log 2>&1 &
+API_PID=$!
+
+# Wait for the server to be ready.
+echo "Starting API server on :$PORT …"
+i=0
+while [ $i -lt 20 ]; do
+  curl -sf "http://localhost:$PORT/healthz" >/dev/null 2>&1 && break
+  sleep 0.5
+  i=$((i+1))
+done
+curl -sf "http://localhost:$PORT/healthz" >/dev/null 2>&1 || { echo "Server failed to start. See /tmp/xrdb-visual-test-server.log" >&2; exit 1; }
+echo "Server ready."
+
+BASE="http://localhost:$PORT"
+
+# Config helpers (inline JSON — the server accepts ?config={...}).
+BACKDROP_LOGO='{"backdropAsPoster":true,"ratings":["imdb","tmdb"],"ratingsLayout":"bottom","badgeStyle":"pill","badgeTheme":"dark"}'
+STANDARD='{"ratings":["imdb","tmdb"],"ratingsLayout":"bottom","badgeStyle":"pill","badgeTheme":"dark"}'
+WITH_PROVIDERS='{"backdropAsPoster":true,"ratings":["imdb","tmdb"],"ratingsLayout":"bottom","providers":true}'
+
+encode() { python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.stdin.read()))" <<EOF
+$1
+EOF
+}
+
+echo "Rendering test images …"
+
+# 1. Backdrop-as-poster with logo overlay — The Dark Knight (tt0468569)
+curl -sf "${BASE}/poster/tt0468569?config=$(encode "$BACKDROP_LOGO")" -o "$OUT/1-backdrop-logo-batman.png" && echo "  1/4 backdrop+logo (Batman)" || echo "  1/4 FAILED"
+
+# 2. Logo letterbox — The Dark Knight
+curl -sf "${BASE}/logo/tt0468569" -o "$OUT/2-logo-letterbox-batman.png" && echo "  2/4 logo letterbox (Batman)" || echo "  2/4 FAILED"
+
+# 3. Standard poster — The Shawshank Redemption (tt0111161)
+curl -sf "${BASE}/poster/tt0111161?config=$(encode "$STANDARD")" -o "$OUT/3-standard-poster-shawshank.png" && echo "  3/4 standard poster (Shawshank)" || echo "  3/4 FAILED"
+
+# 4. Backdrop+logo+providers — Shawshank
+curl -sf "${BASE}/poster/tt0111161?config=$(encode "$WITH_PROVIDERS")" -o "$OUT/4-backdrop-logo-providers-shawshank.png" && echo "  4/4 backdrop+providers (Shawshank)" || echo "  4/4 FAILED"
+
+echo ""
+echo "Images saved to $OUT/"
+ls -lh "$OUT/"*.png 2>/dev/null | awk '{print "  " $5 "  " $9}'
+
+# Open on macOS, display on Linux.
+if command -v open >/dev/null 2>&1; then
+  open "$OUT/"*.png
+elif command -v xdg-open >/dev/null 2>&1; then
+  for f in "$OUT/"*.png; do xdg-open "$f" & done
+fi
+
+echo ""
+echo "Checklist:"
+echo "  [ ] 1-backdrop-logo: title text overlaid on backdrop, scrim visible"
+echo "  [ ] 2-logo-letterbox: full logo shown, no edge clipping"
+echo "  [ ] 3-standard-poster: normal poster, rating badges readable"
+echo "  [ ] 4-backdrop-providers: provider chips above badge row, no overlap"
+echo ""
+echo "Press Ctrl-C to stop the test server."
+wait "$API_PID"

--- a/scripts/visual-test.sh
+++ b/scripts/visual-test.sh
@@ -53,15 +53,19 @@ trap cleanup EXIT INT TERM
 XRDB_ADDR=":$PORT" go run ./cmd/api >/tmp/xrdb-visual-test-server.log 2>&1 &
 API_PID=$!
 
+# All HTTP calls use bounded timeouts so the script cannot hang indefinitely
+# if the local server stalls. 2s connect timeout, 30s overall max per request.
+curl_t() { curl -sSf --connect-timeout 2 --max-time 30 "$@"; }
+
 # Wait for the server to be ready.
 echo "Starting API server on :$PORT …"
 i=0
 while [ $i -lt 20 ]; do
-  curl -sf "http://localhost:$PORT/healthz" >/dev/null 2>&1 && break
+  curl_t "http://localhost:$PORT/healthz" >/dev/null 2>&1 && break
   sleep 0.5
   i=$((i+1))
 done
-curl -sf "http://localhost:$PORT/healthz" >/dev/null 2>&1 || { echo "Server failed to start. See /tmp/xrdb-visual-test-server.log" >&2; exit 1; }
+curl_t "http://localhost:$PORT/healthz" >/dev/null 2>&1 || { echo "Server failed to start. See /tmp/xrdb-visual-test-server.log" >&2; exit 1; }
 echo "Server ready."
 
 BASE="http://localhost:$PORT"
@@ -80,28 +84,28 @@ echo "Rendering test images …"
 failures=0
 
 # 1. Backdrop-as-poster with logo overlay — The Dark Knight (tt0468569)
-if curl -sf "${BASE}/poster/tt0468569?config=$(encode "$BACKDROP_LOGO")" -o "$OUT/1-backdrop-logo-batman.png"; then
+if curl_t "${BASE}/poster/tt0468569?config=$(encode "$BACKDROP_LOGO")" -o "$OUT/1-backdrop-logo-batman.png"; then
   echo "  1/4 backdrop+logo (Batman)"
 else
   echo "  1/4 FAILED" >&2; failures=$((failures+1))
 fi
 
 # 2. Logo letterbox — The Dark Knight
-if curl -sf "${BASE}/logo/tt0468569" -o "$OUT/2-logo-letterbox-batman.png"; then
+if curl_t "${BASE}/logo/tt0468569" -o "$OUT/2-logo-letterbox-batman.png"; then
   echo "  2/4 logo letterbox (Batman)"
 else
   echo "  2/4 FAILED" >&2; failures=$((failures+1))
 fi
 
 # 3. Standard poster — The Shawshank Redemption (tt0111161)
-if curl -sf "${BASE}/poster/tt0111161?config=$(encode "$STANDARD")" -o "$OUT/3-standard-poster-shawshank.png"; then
+if curl_t "${BASE}/poster/tt0111161?config=$(encode "$STANDARD")" -o "$OUT/3-standard-poster-shawshank.png"; then
   echo "  3/4 standard poster (Shawshank)"
 else
   echo "  3/4 FAILED" >&2; failures=$((failures+1))
 fi
 
 # 4. Backdrop+logo+providers — Shawshank
-if curl -sf "${BASE}/poster/tt0111161?config=$(encode "$WITH_PROVIDERS")" -o "$OUT/4-backdrop-logo-providers-shawshank.png"; then
+if curl_t "${BASE}/poster/tt0111161?config=$(encode "$WITH_PROVIDERS")" -o "$OUT/4-backdrop-logo-providers-shawshank.png"; then
   echo "  4/4 backdrop+providers (Shawshank)"
 else
   echo "  4/4 FAILED" >&2; failures=$((failures+1))


### PR DESCRIPTION
## Summary

- **Backdrop logo overlay** (critical bug): When *Use backdrop as poster* is enabled, the title logo now automatically overlays the image. Previously `BackdropLogo` had to be set separately in the config but was never wired up in the UI, so the overlay never appeared.
- **Logo tab sizing**: The `logo` media type now uses `resizeContain` (letterbox) instead of cover-crop, so title text logos are never clipped at the edges.
- **Logo / provider chip anti-collision**: `drawBackdropLogoOverlay` now receives `ratingsH` and positions the logo within the usable area above the bottom strip, preventing it from overlapping provider chips.
- **HDR hierarchy deduplication**: If *Dolby Vision* is present, HDR10+/HDR10/HDR are dropped. If HDR10+ is present, HDR10/HDR are dropped. Eliminates the redundant badge stack visible in the screenshots.
- **Provider chip clearance**: Bottom margin increased from 10 px to 18 px, giving more breathing room above poster title text.
- **Quality badge sizing**: padX/padY/radius bumped for improved legibility.
- **Trending badge**: Capsule shape with drop shadow + top-highlight sheen; arrow prefix (`↑ TRENDING`).
- **CLAUDE.md hard rule**: Added *Verify-Before-Commit* constraint — tests must pass and visual output must be confirmed before any commit.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/compose/... -timeout 120s` — 30/30 pass
- [x] New test `TestBackdropAsPosterAutoEnablesLogoOverlay` — confirms logo fetch is triggered when `BackdropAsPoster=true` even with `BackdropLogo=false`
- [x] New test `TestDedupeQualityTokensHDRHierarchy` — covers DV, HDR10+, HDR10 drop rules
- [x] New test `TestResizeContainNeverExceedsBounds` — confirms canvas size and no-crop guarantee
- [ ] Visual: render `/poster/tt17490712?config=...backdropAsPoster:true...` and confirm logo overlay appears