### PR TITLE
chore(docker): split compose into prebuilt and build-from-source

### DIFF
--- a/compose.build.yaml
+++ b/compose.build.yaml
@@ -1,11 +1,16 @@
 services:
-  # Single container: the web UI is statically exported and embedded in the
-  # Go binary, which serves it alongside the API on the same port.
+  # Builds the image from source before running.
+  # Use this if you want to build your own image rather than pulling from GHCR.
+  # For most users, compose.yaml (pre-built image) is the right choice.
   xrdb:
-    image: ghcr.io/ibbylabs/xrdb:dev
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: xrdb:dev
     container_name: xrdb
     environment:
       XRDB_ADDR: ":8787"
+      XRDB_VERSION: "dev"
       XRDB_DB: "/data/xrdb.db"
       XRDB_CACHE_DIR: "/data/cache"
     ports:

--- a/compose.build.yaml
+++ b/compose.build.yaml
@@ -8,6 +8,9 @@ services:
       dockerfile: Dockerfile
     image: xrdb:dev
     container_name: xrdb
+    env_file:
+      - path: .env
+        required: false
     environment:
       XRDB_ADDR: ":8787"
       XRDB_VERSION: "dev"

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,6 +4,9 @@ services:
   xrdb:
     image: ghcr.io/ibbylabs/xrdb:dev
     container_name: xrdb
+    env_file:
+      - path: .env
+        required: false
     environment:
       XRDB_ADDR: ":8787"
       XRDB_DB: "/data/xrdb.db"

--- a/docs/migrating-to-v3.md
+++ b/docs/migrating-to-v3.md
@@ -23,7 +23,7 @@ simpler configurator.
    ```yaml
    services:
      xrdb:
-       image: ghcr.io/ibbylabs/xrdb:latest
+       image: ghcr.io/ibbylabs/xrdb:dev
        ports: ["8787:8787"]
        volumes: ["xrdb-data:/data"]
        environment:

--- a/env.template
+++ b/env.template
@@ -2,12 +2,18 @@
 # Full reference: variables.md
 #
 # !! MIGRATING FROM v2? Variable names changed — old names are silently ignored:
+#    TMDB_READ_ACCESS_TOKEN / XRDB_TMDB_READ_ACCESS_TOKEN →  XRDB_TMDB_READ_TOKEN
+#    TMDB_API_KEY                    →  XRDB_TMDB_API_KEY
 #    XRDB_README_PREVIEW_TMDB_KEY    →  XRDB_TMDB_API_KEY  (or XRDB_TMDB_READ_TOKEN)
 #    XRDB_README_PREVIEW_MDBLIST_KEY →  XRDB_MDBLIST_API_KEY
 #    MDBLIST_API_KEY                 →  XRDB_MDBLIST_API_KEY
 #    OMDB_KEY                        →  XRDB_OMDB_API_KEY
 #    FANART_API_KEY                  →  XRDB_FANART_API_KEY
 #    SIMKL_CLIENT_ID                 →  XRDB_SIMKL_CLIENT_ID
+#    ADMIN_KEY                       →  XRDB_ADMIN_KEY
+#    XRDB_REQUEST_API_KEY(S)         →  XRDB_API_KEY
+#    XRDB_PORT                       →  XRDB_ADDR
+#    XRDB_DATA_DIR                   →  XRDB_DB + XRDB_CACHE_DIR
 #    NODE_ENV, PORT, HOSTNAME, NEXT_PUBLIC_APP_URL — not used in v3
 #
 # API keys can also be entered via Settings → Integrations in the UI

--- a/env.template
+++ b/env.template
@@ -1,5 +1,17 @@
 # XRDB v3 environment template — copy to .env and fill in what you use.
 # Full reference: variables.md
+#
+# !! MIGRATING FROM v2? Variable names changed — old names are silently ignored:
+#    XRDB_README_PREVIEW_TMDB_KEY    →  XRDB_TMDB_API_KEY  (or XRDB_TMDB_READ_TOKEN)
+#    XRDB_README_PREVIEW_MDBLIST_KEY →  XRDB_MDBLIST_API_KEY
+#    MDBLIST_API_KEY                 →  XRDB_MDBLIST_API_KEY
+#    OMDB_KEY                        →  XRDB_OMDB_API_KEY
+#    FANART_API_KEY                  →  XRDB_FANART_API_KEY
+#    SIMKL_CLIENT_ID                 →  XRDB_SIMKL_CLIENT_ID
+#    NODE_ENV, PORT, HOSTNAME, NEXT_PUBLIC_APP_URL — not used in v3
+#
+# API keys can also be entered via Settings → Integrations in the UI
+# and are stored in the database, so this file is entirely optional.
 
 # ── Server ───────────────────────────────────────────────────────────
 #XRDB_ADDR=:8787
@@ -12,6 +24,7 @@
 #XRDB_API_KEY=
 
 # ── Providers (keys can also be entered on the Integrations page) ────
+# Provide either XRDB_TMDB_READ_TOKEN (preferred) or XRDB_TMDB_API_KEY — not both
 #XRDB_TMDB_READ_TOKEN=
 #XRDB_TMDB_API_KEY=
 #XRDB_MDBLIST_API_KEY=


### PR DESCRIPTION
## Summary
- `compose.yaml` updated to pull `ghcr.io/ibbylabs/xrdb:dev` directly — no build step, correct tag for current branch state so users don't get a stale `latest`
- `compose.build.yaml` added as the build-from-source variant (the old `compose.yaml` content) for devs who want to build the image themselves

## Test plan
- [ ] `docker compose up` pulls `ghcr.io/ibbylabs/xrdb:dev` without building
- [ ] `docker compose -f compose.build.yaml up` builds from source as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new Docker Compose build configuration for local development, including an HTTP health check and a persistent named volume for data.
  * Updated the main Docker Compose setup to use the prebuilt remote development image (with automatic pulls) instead of building locally, simplifying environment variables to set only `XRDB_ADDR`.
* **Documentation**
  * Expanded `env.template` guidance with v2→v3 variable migration (legacy variables ignored) and clarified TMDB credential setup (prefer token over key).
  * Updated the v3 migration compose example to use the `ghcr.io/ibbylabs/xrdb:dev` tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->