### PR TITLE
feat(rings): average rating ring + compact wings (FR-119)

### DIFF
--- a/internal/compose/badge_draw.go
+++ b/internal/compose/badge_draw.go
@@ -75,6 +75,26 @@ func textWidth(face font.Face, s string) int {
 	return font.MeasureString(face, s).Ceil()
 }
 
+// blendPixel alpha-blends color c over the existing pixel at (x, y).
+func blendPixel(dst *image.NRGBA, x, y int, c color.NRGBA) {
+	if !image.Pt(x, y).In(dst.Bounds()) {
+		return
+	}
+	if c.A == 255 {
+		dst.SetNRGBA(x, y, c)
+		return
+	}
+	dp := dst.NRGBAAt(x, y)
+	a := uint32(c.A)
+	ia := 255 - a
+	dst.SetNRGBA(x, y, color.NRGBA{
+		R: uint8((uint32(c.R)*a + uint32(dp.R)*ia) / 255),
+		G: uint8((uint32(c.G)*a + uint32(dp.G)*ia) / 255),
+		B: uint8((uint32(c.B)*a + uint32(dp.B)*ia) / 255),
+		A: uint8((a*255 + uint32(dp.A)*ia) / 255),
+	})
+}
+
 // drawRectBorder draws a 1px border around a rounded rectangle.
 func drawRectBorder(dst *image.NRGBA, r image.Rectangle, radius int, c color.NRGBA) {
 	cr := float64(radius)

--- a/internal/compose/badge_overlay.go
+++ b/internal/compose/badge_overlay.go
@@ -1,10 +1,15 @@
 package compose
 
 import (
+	"encoding/hex"
+	"fmt"
 	"image"
 	"image/color"
+	"math"
 	"strings"
 	"sync"
+
+	"golang.org/x/image/font"
 
 	"xrdb_rewrite/internal/imageconfig"
 	"xrdb_rewrite/internal/provider"
@@ -595,4 +600,285 @@ func drawTrendingBadge(base *image.NRGBA, scale float64) {
 	}
 
 	drawText(base, face, x+padX, y+padY+ascent, color.NRGBA{R: 255, G: 255, B: 255, A: 255}, label)
+}
+
+// ── Average rating ring ───────────────────────────────────────────────────────
+
+// drawAverageRatingRing renders a circular rating ring (or compact wings) in
+// the configured corner. The ring shows the average of the selected rating
+// sources as a progress arc coloured green/amber/red or a custom hex colour.
+func drawAverageRatingRing(base *image.NRGBA, ratings []provider.Rating, cfg imageconfig.Config, scale float64) {
+	if !cfg.RatingRing || len(ratings) == 0 || len(cfg.Ratings) == 0 {
+		return
+	}
+
+	avg, ok := ratingRingAverage(ratings, cfg.Ratings)
+	if !ok {
+		return
+	}
+
+	fillColor := ratingRingFillColor(avg, cfg.RatingRingColor)
+
+	s := func(v float64) int { return int(v*scale + 0.5) }
+	bounds := base.Bounds()
+	edgeX := s(12)
+	edgeY := s(12)
+
+	style := cfg.RatingRingStyle
+	if style == "" {
+		style = "ring"
+	}
+	pos := cfg.RatingRingPos
+	if pos == "" {
+		pos = "br"
+	}
+
+	ensureFaces()
+	valueFace := valueFaceFor(scale)
+
+	switch style {
+	case "compact":
+		drawCompactWings(base, avg, fillColor, pos, bounds, edgeX, edgeY, scale, valueFace)
+	default: // "ring"
+		outerR := s(32)
+		innerR := s(22)
+		cx, cy := ringCenter(pos, bounds, edgeX, edgeY, outerR)
+		drawProgressRing(base, cx, cy, outerR, innerR, avg/10.0, fillColor, valueFace)
+	}
+}
+
+// ratingRingAverage computes the normalised (0–10) average of ratings whose
+// source is in the allowlist. Returns (avg, true) or (0, false) if no data.
+func ratingRingAverage(ratings []provider.Rating, allowed []string) (float64, bool) {
+	allowSet := make(map[string]bool, len(allowed))
+	for _, r := range allowed {
+		allowSet[r] = true
+	}
+	var sum float64
+	var n int
+	for _, r := range ratings {
+		if !allowSet[r.Source] {
+			continue
+		}
+		if r.Value > 0 {
+			sum += r.Value
+			n++
+		}
+	}
+	if n == 0 {
+		return 0, false
+	}
+	return sum / float64(n), true
+}
+
+// ratingRingFillColor returns the arc fill colour: a custom hex when provided,
+// otherwise green/amber/red thresholds matching the aggregate bar.
+func ratingRingFillColor(avg float64, hexColor string) color.NRGBA {
+	if hexColor != "" {
+		if c, err := parseHexColor(hexColor); err == nil {
+			return c
+		}
+	}
+	switch {
+	case avg >= 8.0:
+		return color.NRGBA{R: 39, G: 174, B: 96, A: 230}
+	case avg >= 5.0:
+		return color.NRGBA{R: 230, G: 126, B: 34, A: 230}
+	default:
+		return color.NRGBA{R: 192, G: 57, B: 43, A: 230}
+	}
+}
+
+// parseHexColor parses "#RRGGBB" or "#RGB" into color.NRGBA with A=255.
+func parseHexColor(s string) (color.NRGBA, error) {
+	s = strings.TrimPrefix(strings.TrimSpace(s), "#")
+	if len(s) == 3 {
+		// Expand shorthand
+		s = string([]byte{s[0], s[0], s[1], s[1], s[2], s[2]})
+	}
+	if len(s) != 6 {
+		return color.NRGBA{}, fmt.Errorf("invalid hex color")
+	}
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return color.NRGBA{}, err
+	}
+	return color.NRGBA{R: b[0], G: b[1], B: b[2], A: 255}, nil
+}
+
+// ringCenter returns the pixel center of a ring placed at the given corner.
+func ringCenter(pos string, bounds image.Rectangle, edgeX, edgeY, radius int) (int, int) {
+	switch pos {
+	case "tl":
+		return bounds.Min.X + edgeX + radius, bounds.Min.Y + edgeY + radius
+	case "tr":
+		return bounds.Max.X - edgeX - radius, bounds.Min.Y + edgeY + radius
+	case "bl":
+		return bounds.Min.X + edgeX + radius, bounds.Max.Y - edgeY - radius
+	default: // "br"
+		return bounds.Max.X - edgeX - radius, bounds.Max.Y - edgeY - radius
+	}
+}
+
+// drawProgressRing draws a circular progress arc onto base.
+// sweepFrac is in [0, 1]; the arc starts at the top and goes clockwise.
+func drawProgressRing(base *image.NRGBA, cx, cy, outerR, innerR int, sweepFrac float64, fillColor color.NRGBA, face font.Face) {
+	trackColor := color.NRGBA{R: 0, G: 0, B: 0, A: 140}
+	bgColor := color.NRGBA{R: 0, G: 0, B: 0, A: 160}
+
+	outerR2 := float64(outerR * outerR)
+	innerR2 := float64(innerR * innerR)
+	innerRbg := float64((innerR - 1) * (innerR - 1))
+
+	sweep := sweepFrac * 2 * math.Pi
+	startAngle := -math.Pi / 2 // top
+
+	for py := cy - outerR; py <= cy+outerR; py++ {
+		for px := cx - outerR; px <= cx+outerR; px++ {
+			dx := float64(px) - float64(cx) + 0.5
+			dy := float64(py) - float64(cy) + 0.5
+			d2 := dx*dx + dy*dy
+
+			if d2 < innerRbg {
+				// Inner circle background
+				blendPixel(base, px, py, bgColor)
+				continue
+			}
+			if d2 < innerR2 || d2 > outerR2 {
+				continue
+			}
+			// In the annular ring: check angle for fill vs track
+			angle := math.Atan2(dy, dx)
+			rel := angle - startAngle
+			for rel < 0 {
+				rel += 2 * math.Pi
+			}
+			if rel <= sweep {
+				blendPixel(base, px, py, fillColor)
+			} else {
+				blendPixel(base, px, py, trackColor)
+			}
+		}
+	}
+
+	// Score label centered in the ring
+	if face == nil {
+		return
+	}
+	label := fmt.Sprintf("%.1f", sweepFrac*10)
+	// Trim trailing ".0" for whole numbers to save space
+	if strings.HasSuffix(label, ".0") {
+		label = label[:len(label)-2]
+	}
+	tw := textWidth(face, label)
+	fm := face.Metrics()
+	ascent := fm.Ascent.Ceil()
+	descent := fm.Descent.Ceil()
+	tx := cx - tw/2
+	ty := cy + (ascent-descent)/2
+	drawText(base, face, tx, ty, color.NRGBA{R: 255, G: 255, B: 255, A: 240}, label)
+}
+
+// drawCompactWings draws two small curved arcs flanking the score number,
+// positioned in the requested corner — a compact "wings" style indicator.
+func drawCompactWings(base *image.NRGBA, avg float64, fillColor color.NRGBA, pos string, bounds image.Rectangle, edgeX, edgeY int, scale float64, face font.Face) {
+	if face == nil {
+		return
+	}
+	s := func(v float64) int { return int(v*scale + 0.5) }
+
+	label := fmt.Sprintf("%.1f", avg)
+	if strings.HasSuffix(label, ".0") {
+		label = label[:len(label)-2]
+	}
+
+	tw := textWidth(face, label)
+	fm := face.Metrics()
+	ascent := fm.Ascent.Ceil()
+	descent := fm.Descent.Ceil()
+	textH := ascent + descent
+
+	wingR := s(14) // arc radius
+	padX := s(6)   // gap between text and wing center
+	padY := s(5)
+	totalW := wingR + padX + tw + padX + wingR
+	totalH := textH + padY*2
+
+	// Compute top-left of the widget bounding box
+	var ox, oy int
+	switch pos {
+	case "tl":
+		ox = bounds.Min.X + edgeX
+		oy = bounds.Min.Y + edgeY
+	case "tr":
+		ox = bounds.Max.X - edgeX - totalW
+		oy = bounds.Min.Y + edgeY
+	case "bl":
+		ox = bounds.Min.X + edgeX
+		oy = bounds.Max.Y - edgeY - totalH
+	default: // "br"
+		ox = bounds.Max.X - edgeX - totalW
+		oy = bounds.Max.Y - edgeY - totalH
+	}
+
+	// Background pill behind the whole widget
+	bgRect := image.Rect(ox, oy, ox+totalW, oy+totalH)
+	fillRoundedRect(base, bgRect, totalH/2, color.NRGBA{R: 0, G: 0, B: 0, A: 160})
+
+	cy := oy + totalH/2
+	sweep := (avg / 10.0) * math.Pi * 1.5 // up to 270° per wing at max score
+
+	// Left wing: arc centered left of text, opening rightward (right half of circle)
+	lx := ox + wingR
+	drawArcOnly(base, lx, cy, wingR-s(3), wingR, math.Pi/2, sweep, fillColor)
+
+	// Right wing: arc centered right of text, opening leftward (left half of circle)
+	rx := ox + totalW - wingR
+	drawArcOnly(base, rx, cy, wingR-s(3), wingR, -math.Pi/2, sweep, fillColor)
+
+	// Score text
+	tx := ox + wingR + padX
+	ty := oy + padY + ascent
+	drawText(base, face, tx, ty, color.NRGBA{R: 255, G: 255, B: 255, A: 240}, label)
+}
+
+// drawArcOnly paints pixels in the annular sector defined by [innerR, outerR]
+// and a symmetric sweep of sweepRad radians centred on startAngle.
+func drawArcOnly(base *image.NRGBA, cx, cy, innerR, outerR int, startAngle, sweepRad float64, c color.NRGBA) {
+	outer2 := float64(outerR * outerR)
+	inner2 := float64(innerR * innerR)
+	halfSweep := sweepRad / 2
+	endA := startAngle + halfSweep
+	startA := startAngle - halfSweep
+
+	for py := cy - outerR; py <= cy+outerR; py++ {
+		for px := cx - outerR; px <= cx+outerR; px++ {
+			dx := float64(px) - float64(cx) + 0.5
+			dy := float64(py) - float64(cy) + 0.5
+			d2 := dx*dx + dy*dy
+			if d2 < inner2 || d2 > outer2 {
+				continue
+			}
+			angle := math.Atan2(dy, dx)
+			if angleBetween(angle, startA, endA) {
+				blendPixel(base, px, py, c)
+			}
+		}
+	}
+}
+
+// angleBetween returns true if angle lies in [lo, hi] with wrap-around handling.
+func angleBetween(angle, lo, hi float64) bool {
+	// Normalise both bounds to (-π, π] range that Atan2 returns
+	for lo > math.Pi {
+		lo -= 2 * math.Pi
+	}
+	for lo < -math.Pi {
+		lo += 2 * math.Pi
+	}
+	if lo <= hi {
+		return angle >= lo && angle <= hi
+	}
+	// Wraps around
+	return angle >= lo || angle <= hi
 }

--- a/internal/compose/badge_overlay.go
+++ b/internal/compose/badge_overlay.go
@@ -765,11 +765,7 @@ func drawProgressRing(base *image.NRGBA, cx, cy, outerR, innerR int, sweepFrac f
 	if face == nil {
 		return
 	}
-	label := fmt.Sprintf("%.1f", sweepFrac*10)
-	// Trim trailing ".0" for whole numbers to save space
-	if strings.HasSuffix(label, ".0") {
-		label = label[:len(label)-2]
-	}
+	label := strings.TrimSuffix(fmt.Sprintf("%.1f", sweepFrac*10), ".0")
 	tw := textWidth(face, label)
 	fm := face.Metrics()
 	ascent := fm.Ascent.Ceil()
@@ -787,11 +783,7 @@ func drawCompactWings(base *image.NRGBA, avg float64, fillColor color.NRGBA, pos
 	}
 	s := func(v float64) int { return int(v*scale + 0.5) }
 
-	label := fmt.Sprintf("%.1f", avg)
-	if strings.HasSuffix(label, ".0") {
-		label = label[:len(label)-2]
-	}
-
+	label := strings.TrimSuffix(fmt.Sprintf("%.1f", avg), ".0")
 	tw := textWidth(face, label)
 	fm := face.Metrics()
 	ascent := fm.Ascent.Ceil()
@@ -869,12 +861,18 @@ func drawArcOnly(base *image.NRGBA, cx, cy, innerR, outerR int, startAngle, swee
 
 // angleBetween returns true if angle lies in [lo, hi] with wrap-around handling.
 func angleBetween(angle, lo, hi float64) bool {
-	// Normalise both bounds to (-π, π] range that Atan2 returns
+	// Normalise both bounds to (-π, π] range that Atan2 returns.
 	for lo > math.Pi {
 		lo -= 2 * math.Pi
 	}
 	for lo < -math.Pi {
 		lo += 2 * math.Pi
+	}
+	for hi > math.Pi {
+		hi -= 2 * math.Pi
+	}
+	for hi < -math.Pi {
+		hi += 2 * math.Pi
 	}
 	if lo <= hi {
 		return angle >= lo && angle <= hi

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -171,6 +171,9 @@ func (p *Pipeline) Render(ctx context.Context, req Request) (*Result, error) {
 	if req.Config.Trending {
 		drawTrendingBadge(composed, scale)
 	}
+	if req.Config.RatingRing {
+		drawAverageRatingRing(composed, allRatings, req.Config, scale)
+	}
 	// Show the logo overlay when explicitly requested OR when the user has
 	// chosen to use the backdrop as a poster (backdrop images don't carry
 	// baked-in title text, so the overlay is the only way to show the title).

--- a/internal/imageconfig/config.go
+++ b/internal/imageconfig/config.go
@@ -92,6 +92,10 @@ type Config struct {
 	Trending          bool           `json:"trending"`
 	BackdropAsPoster  bool           `json:"backdropAsPoster,omitempty"`
 	BackdropLogo      bool           `json:"backdropLogo,omitempty"`
+	RatingRing        bool           `json:"ratingRing,omitempty"`
+	RatingRingStyle   string         `json:"ratingRingStyle,omitempty"` // "ring" | "compact"
+	RatingRingPos     string         `json:"ratingRingPos,omitempty"`   // "tl" | "tr" | "bl" | "br"
+	RatingRingColor   string         `json:"ratingRingColor,omitempty"` // "" = auto (green/amber/red), else "#RRGGBB"
 }
 
 // Default returns a Config populated with production defaults.
@@ -132,6 +136,10 @@ type raw struct {
 	Trending         *bool    `json:"trending"`
 	BackdropAsPoster *bool    `json:"backdropAsPoster"`
 	BackdropLogo     *bool    `json:"backdropLogo"`
+	RatingRing       *bool    `json:"ratingRing"`
+	RatingRingStyle  *string  `json:"ratingRingStyle"`
+	RatingRingPos    *string  `json:"ratingRingPos"`
+	RatingRingColor  *string  `json:"ratingRingColor"`
 }
 
 // Parse deserializes a profile config JSON blob into a normalized Config.
@@ -231,6 +239,26 @@ func Parse(data json.RawMessage) Config {
 	if r.BackdropLogo != nil {
 		cfg.BackdropLogo = *r.BackdropLogo
 	}
+	if r.RatingRing != nil {
+		cfg.RatingRing = *r.RatingRing
+	}
+	if r.RatingRingStyle != nil {
+		switch strings.ToLower(strings.TrimSpace(*r.RatingRingStyle)) {
+		case "ring", "full":
+			cfg.RatingRingStyle = "ring"
+		case "compact", "wings":
+			cfg.RatingRingStyle = "compact"
+		}
+	}
+	if r.RatingRingPos != nil {
+		switch strings.ToLower(strings.TrimSpace(*r.RatingRingPos)) {
+		case "tl", "tr", "bl", "br":
+			cfg.RatingRingPos = strings.ToLower(strings.TrimSpace(*r.RatingRingPos))
+		}
+	}
+	if r.RatingRingColor != nil && strings.TrimSpace(*r.RatingRingColor) != "" {
+		cfg.RatingRingColor = strings.TrimSpace(*r.RatingRingColor)
+	}
 	return cfg
 }
 
@@ -260,6 +288,10 @@ func CacheKey(cfg Config) string {
 		Trending         bool           `json:"trending"`
 		BackdropAsPoster bool           `json:"backdropAsPoster"`
 		BackdropLogo     bool           `json:"backdropLogo"`
+		RatingRing       bool           `json:"ratingRing"`
+		RatingRingStyle  string         `json:"ratingRingStyle"`
+		RatingRingPos    string         `json:"ratingRingPos"`
+		RatingRingColor  string         `json:"ratingRingColor"`
 	}
 	ratings := make([]string, len(cfg.Ratings))
 	copy(ratings, cfg.Ratings)
@@ -289,6 +321,10 @@ func CacheKey(cfg Config) string {
 		Trending:         cfg.Trending,
 		BackdropAsPoster: cfg.BackdropAsPoster,
 		BackdropLogo:     cfg.BackdropLogo,
+		RatingRing:       cfg.RatingRing,
+		RatingRingStyle:  cfg.RatingRingStyle,
+		RatingRingPos:    cfg.RatingRingPos,
+		RatingRingColor:  cfg.RatingRingColor,
 	}
 	b, _ := json.Marshal(c)
 	sum := sha256.Sum256(b)

--- a/web/components/configurator-client.tsx
+++ b/web/components/configurator-client.tsx
@@ -88,6 +88,8 @@ export function ConfiguratorClient() {
       providers: cfg.providers, aggregateBar: cfg.aggregateBar,
       aggregateBarPos: cfg.aggregateBarPos, trending: cfg.trending,
       backdropAsPoster: cfg.backdropAsPoster,
+      ratingRing: cfg.ratingRing, ratingRingStyle: cfg.ratingRingStyle,
+      ratingRingPos: cfg.ratingRingPos, ratingRingColor: cfg.ratingRingColor,
     }));
   }, []);
 

--- a/web/components/configurator-display.tsx
+++ b/web/components/configurator-display.tsx
@@ -223,25 +223,29 @@ export function DisplayPanel({ uid, mediaType, config, onUpdate, onToggleBadge, 
           </span>
         </fieldset>
 
-        <ToggleRow
-          label="Aggregate bar"
-          hint="Score bar across the image edge"
-          checked={config.aggregateBar}
-          onChange={() => onUpdate('aggregateBar', !config.aggregateBar)}
-        />
+        {config.ratings.length > 0 && (
+          <>
+            <ToggleRow
+              label="Aggregate bar"
+              hint="Score bar across the image edge"
+              checked={config.aggregateBar}
+              onChange={() => onUpdate('aggregateBar', !config.aggregateBar)}
+            />
 
-        {config.aggregateBar && (
-          <Field label="Bar position" htmlFor={`${uid}-barpos`}>
-            <select
-              id={`${uid}-barpos`}
-              className="select"
-              value={config.aggregateBarPos}
-              onChange={e => onUpdate('aggregateBarPos', e.target.value)}
-            >
-              <option value="bottom">Bottom</option>
-              <option value="top">Top</option>
-            </select>
-          </Field>
+            {config.aggregateBar && (
+              <Field label="Bar position" htmlFor={`${uid}-barpos`}>
+                <select
+                  id={`${uid}-barpos`}
+                  className="select"
+                  value={config.aggregateBarPos}
+                  onChange={e => onUpdate('aggregateBarPos', e.target.value)}
+                >
+                  <option value="bottom">Bottom</option>
+                  <option value="top">Top</option>
+                </select>
+              </Field>
+            )}
+          </>
         )}
 
         <ToggleRow

--- a/web/components/configurator-panels.tsx
+++ b/web/components/configurator-panels.tsx
@@ -95,37 +95,41 @@ export function RatingsPanel({ uid, config, onUpdate, onToggleRating }: RatingsP
           </div>
         </div>
 
-        <div className="field">
-          <span className="label" id={`${uid}-bstyle-label`}>Badge style</span>
-          <div className="opt-grid" style={{ gridTemplateColumns: '1fr 1fr 1fr' }} role="group" aria-labelledby={`${uid}-bstyle-label`}>
-            {BADGE_STYLE_OPTIONS.map(o => (
-              <button
-                key={o.id}
-                className={`opt-btn${config.badgeStyle === o.id ? ' opt-btn--active' : ''}`}
-                onClick={() => onUpdate('badgeStyle', o.id)}
-                aria-pressed={config.badgeStyle === o.id}
-              >
-                {o.label}
-              </button>
-            ))}
-          </div>
-        </div>
+        {config.ratingsLayout !== 'none' && (
+          <>
+            <div className="field">
+              <span className="label" id={`${uid}-bstyle-label`}>Badge style</span>
+              <div className="opt-grid" style={{ gridTemplateColumns: '1fr 1fr 1fr' }} role="group" aria-labelledby={`${uid}-bstyle-label`}>
+                {BADGE_STYLE_OPTIONS.map(o => (
+                  <button
+                    key={o.id}
+                    className={`opt-btn${config.badgeStyle === o.id ? ' opt-btn--active' : ''}`}
+                    onClick={() => onUpdate('badgeStyle', o.id)}
+                    aria-pressed={config.badgeStyle === o.id}
+                  >
+                    {o.label}
+                  </button>
+                ))}
+              </div>
+            </div>
 
-        <div className="field">
-          <span className="label" id={`${uid}-btheme-label`}>Badge theme</span>
-          <div className="opt-grid" role="group" aria-labelledby={`${uid}-btheme-label`}>
-            {BADGE_THEME_OPTIONS.map(o => (
-              <button
-                key={o.id}
-                className={`opt-btn${config.badgeTheme === o.id ? ' opt-btn--active' : ''}`}
-                onClick={() => onUpdate('badgeTheme', o.id)}
-                aria-pressed={config.badgeTheme === o.id}
-              >
-                {o.label}
-              </button>
-            ))}
-          </div>
-        </div>
+            <div className="field">
+              <span className="label" id={`${uid}-btheme-label`}>Badge theme</span>
+              <div className="opt-grid" role="group" aria-labelledby={`${uid}-btheme-label`}>
+                {BADGE_THEME_OPTIONS.map(o => (
+                  <button
+                    key={o.id}
+                    className={`opt-btn${config.badgeTheme === o.id ? ' opt-btn--active' : ''}`}
+                    onClick={() => onUpdate('badgeTheme', o.id)}
+                    aria-pressed={config.badgeTheme === o.id}
+                  >
+                    {o.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </>
+        )}
 
         {config.ratings.length > 0 && (
           <>

--- a/web/components/configurator-panels.tsx
+++ b/web/components/configurator-panels.tsx
@@ -6,6 +6,7 @@ import { fetchTemplates, type Template } from '@/lib/api';
 import type { ConfigState, UpdateConfigFn } from './configurator-types';
 import {
   LAYOUT_OPTIONS, RATING_OPTIONS, BADGE_STYLE_OPTIONS, BADGE_THEME_OPTIONS,
+  RING_STYLE_OPTIONS, RING_POS_OPTIONS,
 } from './configurator-types';
 
 // ── Template strip ────────────────────────────────────────────────────────────
@@ -125,6 +126,77 @@ export function RatingsPanel({ uid, config, onUpdate, onToggleRating }: RatingsP
             ))}
           </div>
         </div>
+
+        {config.ratings.length > 0 && (
+          <>
+            <div className="field">
+              <span className="label" id={`${uid}-ring-label`}>Average ring</span>
+              <div className="opt-grid" style={{ gridTemplateColumns: '1fr 1fr 1fr' }} role="group" aria-labelledby={`${uid}-ring-label`}>
+                <button
+                  className={`opt-btn${!config.ratingRing ? ' opt-btn--active' : ''}`}
+                  onClick={() => onUpdate('ratingRing', false)}
+                  aria-pressed={!config.ratingRing}
+                >
+                  Off
+                </button>
+                {RING_STYLE_OPTIONS.map(o => (
+                  <button
+                    key={o.id}
+                    className={`opt-btn${config.ratingRing && config.ratingRingStyle === o.id ? ' opt-btn--active' : ''}`}
+                    onClick={() => { onUpdate('ratingRing', true); onUpdate('ratingRingStyle', o.id); }}
+                    aria-pressed={config.ratingRing && config.ratingRingStyle === o.id}
+                  >
+                    {o.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {config.ratingRing && (
+              <>
+                <div className="field">
+                  <span className="label" id={`${uid}-ring-pos-label`}>Ring position</span>
+                  <div className="opt-grid" role="group" aria-labelledby={`${uid}-ring-pos-label`}>
+                    {RING_POS_OPTIONS.map(o => (
+                      <button
+                        key={o.id}
+                        className={`opt-btn${config.ratingRingPos === o.id ? ' opt-btn--active' : ''}`}
+                        onClick={() => onUpdate('ratingRingPos', o.id)}
+                        aria-pressed={config.ratingRingPos === o.id}
+                      >
+                        {o.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="field">
+                  <label className="label" htmlFor={`${uid}-ring-color`}>Ring color</label>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--sp-2)' }}>
+                    <input
+                      id={`${uid}-ring-color`}
+                      type="color"
+                      value={config.ratingRingColor || '#27ae60'}
+                      onChange={e => onUpdate('ratingRingColor', e.target.value)}
+                      style={{ width: 36, height: 28, padding: 2, border: '1px solid var(--border)', borderRadius: 4, background: 'none', cursor: 'pointer' }}
+                    />
+                    <button
+                      className={`opt-btn${!config.ratingRingColor ? ' opt-btn--active' : ''}`}
+                      onClick={() => onUpdate('ratingRingColor', '')}
+                      aria-pressed={!config.ratingRingColor}
+                      style={{ flex: 1 }}
+                    >
+                      Auto (score-based)
+                    </button>
+                  </div>
+                  <span className="hint" style={{ marginTop: 'var(--sp-1)' }}>
+                    Auto uses green / amber / red based on the score. Pick a color to override.
+                  </span>
+                </div>
+              </>
+            )}
+          </>
+        )}
 
         <fieldset style={{ border: 'none', padding: 0, margin: 0 }}>
           <legend className="label" style={{ marginBottom: 'var(--sp-2)' }}>

--- a/web/components/configurator-types.ts
+++ b/web/components/configurator-types.ts
@@ -83,6 +83,18 @@ export const GENRE_POS_OPTIONS = [
   { id: 'tr',      label: 'Top right'    },
 ] as const;
 
+export const RING_STYLE_OPTIONS = [
+  { id: 'ring',    label: 'Ring'  },
+  { id: 'compact', label: 'Wings' },
+] as const;
+
+export const RING_POS_OPTIONS = [
+  { id: 'br', label: 'Bottom right' },
+  { id: 'bl', label: 'Bottom left'  },
+  { id: 'tr', label: 'Top right'    },
+  { id: 'tl', label: 'Top left'     },
+] as const;
+
 export const QUALITY_BADGE_OPTIONS: { id: string; label: string }[] = [
   { id: '4k',        label: '4K'           },
   { id: 'hdr',       label: 'HDR'          },
@@ -116,6 +128,10 @@ export interface ConfigState {
   aggregateBarPos: string;
   trending: boolean;
   backdropAsPoster: boolean;
+  ratingRing: boolean;
+  ratingRingStyle: string;
+  ratingRingPos: string;
+  ratingRingColor: string;
 }
 
 export const DEFAULT_CONFIG: ConfigState = {
@@ -137,6 +153,10 @@ export const DEFAULT_CONFIG: ConfigState = {
   aggregateBarPos: 'bottom',
   trending: false,
   backdropAsPoster: false,
+  ratingRing: false,
+  ratingRingStyle: 'ring',
+  ratingRingPos: 'br',
+  ratingRingColor: '',
 };
 
 export type UpdateConfigFn = <K extends keyof ConfigState>(key: K, value: ConfigState[K]) => void;


### PR DESCRIPTION
## Summary

- Restores the v2 average rating ring, lost during the v3 rewrite (FR-119)
- Two styles: **Ring** (circular progress indicator) and **Wings** (compact arc pair flanking the score)
- Four corner positions: top-left, top-right, bottom-left, bottom-right
- Color: auto (green ≥8.0 / amber ≥5.0 / red <5.0) or a custom hex color the user picks
- Ring controls are **hidden when no rating sources are selected** — enforces the new hard rule that incompatible options disappear rather than persist in a broken state
- Ring position and color sub-controls are **hidden when the ring is off**

## Changes

| Layer | Files |
|---|---|
| Config | `internal/imageconfig/config.go` — 4 new fields with parse/cache-key/canonical-JSON |
| Render | `internal/compose/badge_overlay.go` — `drawAverageRatingRing`, `drawProgressRing`, `drawCompactWings`, `drawArcOnly`, hex color parser |
| Render | `internal/compose/badge_draw.go` — `blendPixel` helper |
| Render | `internal/compose/compose.go` — calls ring draw after trending badge |
| UI | `web/components/configurator-types.ts` — `RING_STYLE_OPTIONS`, `RING_POS_OPTIONS`, 4 new `ConfigState` fields |
| UI | `web/components/configurator-panels.tsx` — ring controls in `RatingsPanel`, gated on `ratings.length > 0` |
| UI | `web/components/configurator-client.tsx` — forwards ring fields in `buildSrc` |

## Test plan

- [x] `go test ./...` — 241 tests pass
- [x] `npx tsc --noEmit` — no TypeScript errors
- [x] Visual: ring style renders green progress circle with score centered (Dark Knight = 8.8, green)
- [x] Visual: compact wings style renders arc pair with custom blue color
- [x] Visual: both position correctly in the corner, scale-aware
- [ ] Confirm ring is hidden in configurator when ratings list is empty
- [ ] Confirm position/color controls collapse when ring is set to Off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an average rating ring overlay to badge rendering, with ring and compact (“wings”) styles, selectable corner positioning, and either score-based colouring or a custom hex colour (with auto/score option).
  * Extended the configurator with an “Average ring” section (enable/disable, style, position, and colour) and updated preview rendering to include these settings.
* **UI Improvements**
  * Only shows the “Aggregate bar” controls when ratings are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->