### PR TITLE
fix(compose): anti-alias badge corners and ring edges (BUG-160)

### DIFF
--- a/internal/compose/badge_draw.go
+++ b/internal/compose/badge_draw.go
@@ -13,23 +13,15 @@ import (
 func fillRoundedRect(dst *image.NRGBA, r image.Rectangle, radius int, c color.NRGBA) {
 	bounds := dst.Bounds()
 	r = r.Intersect(bounds)
-	cr := float64(radius)
 	for y := r.Min.Y; y < r.Max.Y; y++ {
 		for x := r.Min.X; x < r.Max.X; x++ {
-			if inCornerZone(x, y, r, radius) {
-				cx, cy := cornerCenter(x, y, r, radius)
-				dx := float64(x) - cx + 0.5
-				dy := float64(y) - cy + 0.5
-				dist := math.Sqrt(dx*dx + dy*dy)
-				if dist >= cr+0.5 {
-					continue
-				}
-				if dist > cr-0.5 {
-					// Sub-pixel coverage at the arc edge — blend instead of hard clip.
-					coverage := cr + 0.5 - dist
-					blendPixel(dst, x, y, color.NRGBA{R: c.R, G: c.G, B: c.B, A: uint8(float64(c.A) * coverage)})
-					continue
-				}
+			cov, skip := cornerCoverage(x, y, r, radius)
+			if skip {
+				continue
+			}
+			if cov < 1 {
+				blendPixel(dst, x, y, color.NRGBA{R: c.R, G: c.G, B: c.B, A: uint8(float64(c.A) * cov)})
+				continue
 			}
 			dst.SetNRGBA(x, y, c)
 		}
@@ -54,6 +46,28 @@ func cornerCenter(x, y int, r image.Rectangle, radius int) (float64, float64) {
 		cy = float64(r.Max.Y - radius)
 	}
 	return cx, cy
+}
+
+// cornerCoverage returns the anti-aliased sub-pixel coverage for (x, y) at the
+// rounded corners of r. skip=true means the pixel is outside the arc and should
+// be discarded. When skip is false, coverage is in (0,1]: callers should blend
+// at partial alpha when coverage < 1, or write fully when coverage == 1.
+func cornerCoverage(x, y int, r image.Rectangle, radius int) (coverage float64, skip bool) {
+	if !inCornerZone(x, y, r, radius) {
+		return 1, false
+	}
+	cx, cy := cornerCenter(x, y, r, radius)
+	dx := float64(x) - cx + 0.5
+	dy := float64(y) - cy + 0.5
+	cr := float64(radius)
+	dist := math.Sqrt(dx*dx + dy*dy)
+	if dist >= cr+0.5 {
+		return 0, true
+	}
+	if dist > cr-0.5 {
+		return cr + 0.5 - dist, false
+	}
+	return 1, false
 }
 
 // fillRect fills a rectangle on dst with c (no alpha blending).
@@ -105,7 +119,6 @@ func blendPixel(dst *image.NRGBA, x, y int, c color.NRGBA) {
 
 // drawRectBorder draws a 1px border around a rounded rectangle.
 func drawRectBorder(dst *image.NRGBA, r image.Rectangle, radius int, c color.NRGBA) {
-	cr := float64(radius)
 	b := dst.Bounds()
 	for x := r.Min.X; x < r.Max.X; x++ {
 		onEdge := x == r.Min.X || x == r.Max.X-1
@@ -117,19 +130,13 @@ func drawRectBorder(dst *image.NRGBA, r image.Rectangle, radius int, c color.NRG
 			if !pt.In(b) {
 				continue
 			}
-			if inCornerZone(x, y, r, radius) {
-				cx, cy := cornerCenter(x, y, r, radius)
-				dx := float64(x) - cx + 0.5
-				dy := float64(y) - cy + 0.5
-				dist := math.Sqrt(dx*dx + dy*dy)
-				if dist >= cr+0.5 {
-					continue
-				}
-				if dist > cr-0.5 {
-					coverage := cr + 0.5 - dist
-					blendPixel(dst, x, y, color.NRGBA{R: c.R, G: c.G, B: c.B, A: uint8(float64(c.A) * coverage)})
-					continue
-				}
+			cov, skip := cornerCoverage(x, y, r, radius)
+			if skip {
+				continue
+			}
+			if cov < 1 {
+				blendPixel(dst, x, y, color.NRGBA{R: c.R, G: c.G, B: c.B, A: uint8(float64(c.A) * cov)})
+				continue
 			}
 			dst.SetNRGBA(x, y, c)
 		}

--- a/internal/compose/badge_draw.go
+++ b/internal/compose/badge_draw.go
@@ -3,6 +3,7 @@ package compose
 import (
 	"image"
 	"image/color"
+	"math"
 
 	"golang.org/x/image/font"
 	"golang.org/x/image/math/fixed"
@@ -19,7 +20,14 @@ func fillRoundedRect(dst *image.NRGBA, r image.Rectangle, radius int, c color.NR
 				cx, cy := cornerCenter(x, y, r, radius)
 				dx := float64(x) - cx + 0.5
 				dy := float64(y) - cy + 0.5
-				if dx*dx+dy*dy > cr*cr {
+				dist := math.Sqrt(dx*dx + dy*dy)
+				if dist >= cr+0.5 {
+					continue
+				}
+				if dist > cr-0.5 {
+					// Sub-pixel coverage at the arc edge — blend instead of hard clip.
+					coverage := cr + 0.5 - dist
+					blendPixel(dst, x, y, color.NRGBA{R: c.R, G: c.G, B: c.B, A: uint8(float64(c.A) * coverage)})
 					continue
 				}
 			}
@@ -113,7 +121,13 @@ func drawRectBorder(dst *image.NRGBA, r image.Rectangle, radius int, c color.NRG
 				cx, cy := cornerCenter(x, y, r, radius)
 				dx := float64(x) - cx + 0.5
 				dy := float64(y) - cy + 0.5
-				if dx*dx+dy*dy > cr*cr {
+				dist := math.Sqrt(dx*dx + dy*dy)
+				if dist >= cr+0.5 {
+					continue
+				}
+				if dist > cr-0.5 {
+					coverage := cr + 0.5 - dist
+					blendPixel(dst, x, y, color.NRGBA{R: c.R, G: c.G, B: c.B, A: uint8(float64(c.A) * coverage)})
 					continue
 				}
 			}

--- a/internal/compose/badge_overlay.go
+++ b/internal/compose/badge_overlay.go
@@ -726,38 +726,60 @@ func drawProgressRing(base *image.NRGBA, cx, cy, outerR, innerR int, sweepFrac f
 	trackColor := color.NRGBA{R: 0, G: 0, B: 0, A: 140}
 	bgColor := color.NRGBA{R: 0, G: 0, B: 0, A: 160}
 
-	outerR2 := float64(outerR * outerR)
-	innerR2 := float64(innerR * innerR)
-	innerRbg := float64((innerR - 1) * (innerR - 1))
+	outerRf := float64(outerR)
+	innerRf := float64(innerR)
+	innerBgRf := float64(innerR - 1)
 
 	sweep := sweepFrac * 2 * math.Pi
 	startAngle := -math.Pi / 2 // top
 
-	for py := cy - outerR; py <= cy+outerR; py++ {
-		for px := cx - outerR; px <= cx+outerR; px++ {
+	for py := cy - outerR - 1; py <= cy+outerR+1; py++ {
+		for px := cx - outerR - 1; px <= cx+outerR+1; px++ {
 			dx := float64(px) - float64(cx) + 0.5
 			dy := float64(py) - float64(cy) + 0.5
-			d2 := dx*dx + dy*dy
+			dist := math.Sqrt(dx*dx + dy*dy)
 
-			if d2 < innerRbg {
-				// Inner circle background
-				blendPixel(base, px, py, bgColor)
+			// Outer edge coverage: fade out beyond outerR.
+			outerCov := outerRf + 0.5 - dist
+			if outerCov <= 0 {
 				continue
 			}
-			if d2 < innerR2 || d2 > outerR2 {
+			if outerCov > 1 {
+				outerCov = 1
+			}
+
+			// Inner background disk (full solid fill inside innerR-1).
+			bgCov := innerBgRf + 0.5 - dist
+			if bgCov > 1 {
+				bgCov = 1
+			}
+			if bgCov > 0 {
+				blendPixel(base, px, py, color.NRGBA{R: bgColor.R, G: bgColor.G, B: bgColor.B, A: uint8(float64(bgColor.A) * bgCov * outerCov)})
 				continue
 			}
-			// In the annular ring: check angle for fill vs track
+
+			// Annular ring zone. Skip pixels fully inside the inner hole.
+			innerCov := dist - (innerRf - 0.5)
+			if innerCov <= 0 {
+				continue
+			}
+			if innerCov > 1 {
+				innerCov = 1
+			}
+
+			ringAlpha := outerCov * innerCov
 			angle := math.Atan2(dy, dx)
 			rel := angle - startAngle
 			for rel < 0 {
 				rel += 2 * math.Pi
 			}
+			var c color.NRGBA
 			if rel <= sweep {
-				blendPixel(base, px, py, fillColor)
+				c = fillColor
 			} else {
-				blendPixel(base, px, py, trackColor)
+				c = trackColor
 			}
+			blendPixel(base, px, py, color.NRGBA{R: c.R, G: c.G, B: c.B, A: uint8(float64(c.A) * ringAlpha)})
 		}
 	}
 


### PR DESCRIPTION
## Summary

- **Root cause:** `fillRoundedRect`, `drawRectBorder`, and `drawProgressRing` all used a hard binary in/out test at curved pixel boundaries — a pixel was either fully filled or fully skipped, producing visible staircase jaggies on every rounded badge chip and rating ring.
- **Fix:** Switch to sub-pixel coverage blending within ±0.5px of each arc boundary. The existing `blendPixel` helper is used to composite partial-alpha edge pixels, giving smooth anti-aliased curves.
- **Scope:** All badge types are affected positively — rating pills, age rating chip, genre badge, quality badges, trending badge, provider badges, and the average rating ring.

## Test plan

- [x] `go test ./...` — 241 tests pass
- [x] Visual render check: `/poster/tt0468569` with ratings, ring, age rating, genre — rounded corners and ring edges render smoothly with no staircase artifacts
- [x] No API or signature changes; purely internal pixel-level rendering fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Visual Improvements**
  * Rounded corners and badge edges now render with improved anti-aliasing using smoother per-pixel coverage blending.
  * Progress ring rendering has been updated for more continuous, anti-aliased edges, with coverage-aware blending for smoother transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->