### PR TITLE
fix(compose): remove wings overlay, sharpen rendering quality

### DIFF
--- a/internal/compose/backdrop.go
+++ b/internal/compose/backdrop.go
@@ -120,7 +120,7 @@ func resizeFitSmart(src image.Image, maxW, maxH int) image.Image {
 	}
 
 	scaled := image.NewNRGBA(image.Rect(0, 0, scaledW, scaledH))
-	xdraw.BiLinear.Scale(scaled, scaled.Bounds(), src, srcB, xdraw.Over, nil)
+	xdraw.CatmullRom.Scale(scaled, scaled.Bounds(), src, srcB, xdraw.Over, nil)
 
 	offX, offY := saliencyCropOffset(scaled, maxW, maxH)
 
@@ -157,7 +157,7 @@ func resizeContain(src image.Image, maxW, maxH int) image.Image {
 
 	dst := image.NewNRGBA(image.Rect(0, 0, maxW, maxH))
 	scaled := image.NewNRGBA(image.Rect(0, 0, scaledW, scaledH))
-	xdraw.BiLinear.Scale(scaled, scaled.Bounds(), src, srcB, xdraw.Over, nil)
+	xdraw.CatmullRom.Scale(scaled, scaled.Bounds(), src, srcB, xdraw.Over, nil)
 
 	offX := (maxW - scaledW) / 2
 	offY := (maxH - scaledH) / 2

--- a/internal/compose/badge.go
+++ b/internal/compose/badge.go
@@ -26,8 +26,8 @@ var ratingIconFS embed.FS
 
 var (
 	onceFaces sync.Once
-	faceValue font.Face // 14px bold — rating value (normal scale)
-	faceLabel font.Face // 11px regular — overlay labels (normal scale)
+	faceValue font.Face // 22pt bold — rating value (normal scale)
+	faceLabel font.Face // 17pt regular — overlay labels (normal scale)
 
 	onceIcons   sync.Once
 	ratingIcons map[string]image.Image
@@ -48,7 +48,7 @@ func ensureFaces() {
 		} else {
 			fontBoldParsed = tt
 			if f, err := opentype.NewFace(tt, &opentype.FaceOptions{
-				Size: 16, DPI: 96, Hinting: font.HintingFull,
+				Size: 22, DPI: 96, Hinting: font.HintingFull,
 			}); err != nil {
 				log.Printf("compose: create bold face: %v", err)
 			} else {
@@ -60,7 +60,7 @@ func ensureFaces() {
 		} else {
 			fontRegularParsed = tt
 			if f, err := opentype.NewFace(tt, &opentype.FaceOptions{
-				Size: 13, DPI: 96, Hinting: font.HintingFull,
+				Size: 17, DPI: 96, Hinting: font.HintingFull,
 			}); err != nil {
 				log.Printf("compose: create regular face: %v", err)
 			} else {
@@ -102,7 +102,7 @@ func valueFaceFor(scale float64) font.Face {
 		return f.(font.Face)
 	}
 	f, err := opentype.NewFace(fontBoldParsed, &opentype.FaceOptions{
-		Size: 16 * scale, DPI: 96, Hinting: font.HintingFull,
+		Size: 22 * scale, DPI: 96, Hinting: font.HintingFull,
 	})
 	if err != nil {
 		return faceValue
@@ -122,7 +122,7 @@ func labelFaceFor(scale float64) font.Face {
 		return f.(font.Face)
 	}
 	f, err := opentype.NewFace(fontRegularParsed, &opentype.FaceOptions{
-		Size: 13 * scale, DPI: 96, Hinting: font.HintingFull,
+		Size: 17 * scale, DPI: 96, Hinting: font.HintingFull,
 	})
 	if err != nil {
 		return faceLabel
@@ -298,15 +298,15 @@ func drawBadgesInPlace(out *image.NRGBA, ratings []provider.Rating, cfg imagecon
 	valH := valAscent + valDescent
 
 	var (
-		accentW  = s(3)
-		padX     = s(10)
-		padY     = s(7)
-		iconSize = s(20)
-		iconGap  = s(5)
-		badgeGap = s(8)
-		rowGap   = s(8)
-		edgeX    = s(12)
-		edgeY    = s(12)
+		accentW  = s(4)
+		padX     = s(14)
+		padY     = s(10)
+		iconSize = s(28)
+		iconGap  = s(7)
+		badgeGap = s(11)
+		rowGap   = s(11)
+		edgeX    = s(16)
+		edgeY    = s(16)
 	)
 
 	innerH := padY*2 + maxInt(valH, iconSize)

--- a/internal/compose/badge.go
+++ b/internal/compose/badge.go
@@ -48,7 +48,7 @@ func ensureFaces() {
 		} else {
 			fontBoldParsed = tt
 			if f, err := opentype.NewFace(tt, &opentype.FaceOptions{
-				Size: 14, DPI: 72, Hinting: font.HintingFull,
+				Size: 16, DPI: 96, Hinting: font.HintingFull,
 			}); err != nil {
 				log.Printf("compose: create bold face: %v", err)
 			} else {
@@ -60,7 +60,7 @@ func ensureFaces() {
 		} else {
 			fontRegularParsed = tt
 			if f, err := opentype.NewFace(tt, &opentype.FaceOptions{
-				Size: 11, DPI: 72, Hinting: font.HintingFull,
+				Size: 13, DPI: 96, Hinting: font.HintingFull,
 			}); err != nil {
 				log.Printf("compose: create regular face: %v", err)
 			} else {
@@ -102,7 +102,7 @@ func valueFaceFor(scale float64) font.Face {
 		return f.(font.Face)
 	}
 	f, err := opentype.NewFace(fontBoldParsed, &opentype.FaceOptions{
-		Size: 14 * scale, DPI: 72, Hinting: font.HintingFull,
+		Size: 16 * scale, DPI: 96, Hinting: font.HintingFull,
 	})
 	if err != nil {
 		return faceValue
@@ -122,7 +122,7 @@ func labelFaceFor(scale float64) font.Face {
 		return f.(font.Face)
 	}
 	f, err := opentype.NewFace(fontRegularParsed, &opentype.FaceOptions{
-		Size: 11 * scale, DPI: 72, Hinting: font.HintingFull,
+		Size: 13 * scale, DPI: 96, Hinting: font.HintingFull,
 	})
 	if err != nil {
 		return faceLabel
@@ -299,12 +299,12 @@ func drawBadgesInPlace(out *image.NRGBA, ratings []provider.Rating, cfg imagecon
 
 	var (
 		accentW  = s(3)
-		padX     = s(9)
-		padY     = s(6)
-		iconSize = s(17)
+		padX     = s(10)
+		padY     = s(7)
+		iconSize = s(20)
 		iconGap  = s(5)
-		badgeGap = s(7)
-		rowGap   = s(7)
+		badgeGap = s(8)
+		rowGap   = s(8)
 		edgeX    = s(12)
 		edgeY    = s(12)
 	)

--- a/internal/compose/badge_overlay.go
+++ b/internal/compose/badge_overlay.go
@@ -387,10 +387,10 @@ func drawLogoScaled(dst *image.NRGBA, src *image.NRGBA, dstRect image.Rectangle)
 			a := uint32(sp.A)
 			ia := 255 - a
 			dst.SetNRGBA(px, py, color.NRGBA{
-				R: uint8((uint32(sp.R)*a + uint32(dp.R)*ia) / 255),
-				G: uint8((uint32(sp.G)*a + uint32(dp.G)*ia) / 255),
-				B: uint8((uint32(sp.B)*a + uint32(dp.B)*ia) / 255),
-				A: uint8((a*255 + uint32(dp.A)*ia) / 255),
+				R: uint8((uint32(sp.R)*a + uint32(dp.R)*uint32(dp.A)*ia/255) / 255),
+				G: uint8((uint32(sp.G)*a + uint32(dp.G)*uint32(dp.A)*ia/255) / 255),
+				B: uint8((uint32(sp.B)*a + uint32(dp.B)*uint32(dp.A)*ia/255) / 255),
+				A: uint8(a + uint32(dp.A)*ia/255),
 			})
 		}
 	}

--- a/internal/compose/badge_overlay.go
+++ b/internal/compose/badge_overlay.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	xdraw "golang.org/x/image/draw"
 	"golang.org/x/image/font"
 
 	"xrdb_rewrite/internal/imageconfig"
@@ -357,25 +358,24 @@ func drawProviderBadges(base *image.NRGBA, providers []provider.WatchProvider, s
 	}
 }
 
-// drawLogoScaled composites src into dst rectangle using nearest-neighbour
-// scaling. Transparent logo pixels are skipped (src has straight alpha).
+// drawLogoScaled composites src into dst rectangle using CatmullRom
+// resampling for sharp, high-quality scaling. Alpha is composited over
+// the existing destination pixels.
 func drawLogoScaled(dst *image.NRGBA, src *image.NRGBA, dstRect image.Rectangle) {
-	sb := src.Bounds()
-	dw := dstRect.Dx()
-	dh := dstRect.Dy()
-	if dw <= 0 || dh <= 0 || sb.Dx() <= 0 || sb.Dy() <= 0 {
+	if dstRect.Dx() <= 0 || dstRect.Dy() <= 0 || src.Bounds().Dx() <= 0 || src.Bounds().Dy() <= 0 {
 		return
 	}
-	for dy := 0; dy < dh; dy++ {
-		sy := sb.Min.Y + dy*sb.Dy()/dh
-		for dx := 0; dx < dw; dx++ {
-			sx := sb.Min.X + dx*sb.Dx()/dw
-			sp := src.NRGBAAt(sx, sy)
+	scaled := image.NewNRGBA(image.Rect(0, 0, dstRect.Dx(), dstRect.Dy()))
+	xdraw.CatmullRom.Scale(scaled, scaled.Bounds(), src, src.Bounds(), xdraw.Over, nil)
+	sb := scaled.Bounds()
+	for py := dstRect.Min.Y; py < dstRect.Max.Y; py++ {
+		sy := sb.Min.Y + (py - dstRect.Min.Y)
+		for px := dstRect.Min.X; px < dstRect.Max.X; px++ {
+			sx := sb.Min.X + (px - dstRect.Min.X)
+			sp := scaled.NRGBAAt(sx, sy)
 			if sp.A == 0 {
 				continue
 			}
-			px := dstRect.Min.X + dx
-			py := dstRect.Min.Y + dy
 			if !image.Pt(px, py).In(dst.Bounds()) {
 				continue
 			}
@@ -383,7 +383,6 @@ func drawLogoScaled(dst *image.NRGBA, src *image.NRGBA, dstRect image.Rectangle)
 				dst.SetNRGBA(px, py, sp)
 				continue
 			}
-			// Alpha blend over existing pixel.
 			dp := dst.NRGBAAt(px, py)
 			a := uint32(sp.A)
 			ia := 255 - a
@@ -604,9 +603,9 @@ func drawTrendingBadge(base *image.NRGBA, scale float64) {
 
 // ── Average rating ring ───────────────────────────────────────────────────────
 
-// drawAverageRatingRing renders a circular rating ring (or compact wings) in
-// the configured corner. The ring shows the average of the selected rating
-// sources as a progress arc coloured green/amber/red or a custom hex colour.
+// drawAverageRatingRing renders a circular progress ring in the configured
+// corner. The ring shows the average of the selected rating sources as a
+// progress arc coloured green/amber/red or a custom hex colour.
 func drawAverageRatingRing(base *image.NRGBA, ratings []provider.Rating, cfg imageconfig.Config, scale float64) {
 	if !cfg.RatingRing || len(ratings) == 0 || len(cfg.Ratings) == 0 {
 		return
@@ -624,10 +623,6 @@ func drawAverageRatingRing(base *image.NRGBA, ratings []provider.Rating, cfg ima
 	edgeX := s(12)
 	edgeY := s(12)
 
-	style := cfg.RatingRingStyle
-	if style == "" {
-		style = "ring"
-	}
 	pos := cfg.RatingRingPos
 	if pos == "" {
 		pos = "br"
@@ -636,15 +631,10 @@ func drawAverageRatingRing(base *image.NRGBA, ratings []provider.Rating, cfg ima
 	ensureFaces()
 	valueFace := valueFaceFor(scale)
 
-	switch style {
-	case "compact":
-		drawCompactWings(base, avg, fillColor, pos, bounds, edgeX, edgeY, scale, valueFace)
-	default: // "ring"
-		outerR := s(32)
-		innerR := s(22)
-		cx, cy := ringCenter(pos, bounds, edgeX, edgeY, outerR)
-		drawProgressRing(base, cx, cy, outerR, innerR, avg/10.0, fillColor, valueFace)
-	}
+	outerR := s(32)
+	innerR := s(22)
+	cx, cy := ringCenter(pos, bounds, edgeX, edgeY, outerR)
+	drawProgressRing(base, cx, cy, outerR, innerR, avg/10.0, fillColor, valueFace)
 }
 
 // ratingRingAverage computes the normalised (0–10) average of ratings whose
@@ -797,108 +787,3 @@ func drawProgressRing(base *image.NRGBA, cx, cy, outerR, innerR int, sweepFrac f
 	drawText(base, face, tx, ty, color.NRGBA{R: 255, G: 255, B: 255, A: 240}, label)
 }
 
-// drawCompactWings draws two small curved arcs flanking the score number,
-// positioned in the requested corner — a compact "wings" style indicator.
-func drawCompactWings(base *image.NRGBA, avg float64, fillColor color.NRGBA, pos string, bounds image.Rectangle, edgeX, edgeY int, scale float64, face font.Face) {
-	if face == nil {
-		return
-	}
-	s := func(v float64) int { return int(v*scale + 0.5) }
-
-	label := strings.TrimSuffix(fmt.Sprintf("%.1f", avg), ".0")
-	tw := textWidth(face, label)
-	fm := face.Metrics()
-	ascent := fm.Ascent.Ceil()
-	descent := fm.Descent.Ceil()
-	textH := ascent + descent
-
-	wingR := s(14) // arc radius
-	padX := s(6)   // gap between text and wing center
-	padY := s(5)
-	totalW := wingR + padX + tw + padX + wingR
-	totalH := textH + padY*2
-
-	// Compute top-left of the widget bounding box
-	var ox, oy int
-	switch pos {
-	case "tl":
-		ox = bounds.Min.X + edgeX
-		oy = bounds.Min.Y + edgeY
-	case "tr":
-		ox = bounds.Max.X - edgeX - totalW
-		oy = bounds.Min.Y + edgeY
-	case "bl":
-		ox = bounds.Min.X + edgeX
-		oy = bounds.Max.Y - edgeY - totalH
-	default: // "br"
-		ox = bounds.Max.X - edgeX - totalW
-		oy = bounds.Max.Y - edgeY - totalH
-	}
-
-	// Background pill behind the whole widget
-	bgRect := image.Rect(ox, oy, ox+totalW, oy+totalH)
-	fillRoundedRect(base, bgRect, totalH/2, color.NRGBA{R: 0, G: 0, B: 0, A: 160})
-
-	cy := oy + totalH/2
-	sweep := (avg / 10.0) * math.Pi * 1.5 // up to 270° per wing at max score
-
-	// Left wing: arc centered left of text, opening rightward (right half of circle)
-	lx := ox + wingR
-	drawArcOnly(base, lx, cy, wingR-s(3), wingR, math.Pi/2, sweep, fillColor)
-
-	// Right wing: arc centered right of text, opening leftward (left half of circle)
-	rx := ox + totalW - wingR
-	drawArcOnly(base, rx, cy, wingR-s(3), wingR, -math.Pi/2, sweep, fillColor)
-
-	// Score text
-	tx := ox + wingR + padX
-	ty := oy + padY + ascent
-	drawText(base, face, tx, ty, color.NRGBA{R: 255, G: 255, B: 255, A: 240}, label)
-}
-
-// drawArcOnly paints pixels in the annular sector defined by [innerR, outerR]
-// and a symmetric sweep of sweepRad radians centred on startAngle.
-func drawArcOnly(base *image.NRGBA, cx, cy, innerR, outerR int, startAngle, sweepRad float64, c color.NRGBA) {
-	outer2 := float64(outerR * outerR)
-	inner2 := float64(innerR * innerR)
-	halfSweep := sweepRad / 2
-	endA := startAngle + halfSweep
-	startA := startAngle - halfSweep
-
-	for py := cy - outerR; py <= cy+outerR; py++ {
-		for px := cx - outerR; px <= cx+outerR; px++ {
-			dx := float64(px) - float64(cx) + 0.5
-			dy := float64(py) - float64(cy) + 0.5
-			d2 := dx*dx + dy*dy
-			if d2 < inner2 || d2 > outer2 {
-				continue
-			}
-			angle := math.Atan2(dy, dx)
-			if angleBetween(angle, startA, endA) {
-				blendPixel(base, px, py, c)
-			}
-		}
-	}
-}
-
-// angleBetween returns true if angle lies in [lo, hi] with wrap-around handling.
-func angleBetween(angle, lo, hi float64) bool {
-	// Normalise both bounds to (-π, π] range that Atan2 returns.
-	for lo > math.Pi {
-		lo -= 2 * math.Pi
-	}
-	for lo < -math.Pi {
-		lo += 2 * math.Pi
-	}
-	for hi > math.Pi {
-		hi -= 2 * math.Pi
-	}
-	for hi < -math.Pi {
-		hi += 2 * math.Pi
-	}
-	if lo <= hi {
-		return angle >= lo && angle <= hi
-	}
-	// Wraps around
-	return angle >= lo || angle <= hi
-}

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -325,7 +325,7 @@ func resizeFit(src image.Image, maxW, maxH int) image.Image {
 	}
 
 	scaled := image.NewNRGBA(image.Rect(0, 0, scaledW, scaledH))
-	xdraw.BiLinear.Scale(scaled, scaled.Bounds(), src, srcB, xdraw.Over, nil)
+	xdraw.CatmullRom.Scale(scaled, scaled.Bounds(), src, srcB, xdraw.Over, nil)
 
 	offsetX := (scaledW - maxW) / 2
 	offsetY := (scaledH - maxH) / 2

--- a/internal/imageconfig/config.go
+++ b/internal/imageconfig/config.go
@@ -92,10 +92,9 @@ type Config struct {
 	Trending          bool           `json:"trending"`
 	BackdropAsPoster  bool           `json:"backdropAsPoster,omitempty"`
 	BackdropLogo      bool           `json:"backdropLogo,omitempty"`
-	RatingRing        bool           `json:"ratingRing,omitempty"`
-	RatingRingStyle   string         `json:"ratingRingStyle,omitempty"` // "ring" | "compact"
-	RatingRingPos     string         `json:"ratingRingPos,omitempty"`   // "tl" | "tr" | "bl" | "br"
-	RatingRingColor   string         `json:"ratingRingColor,omitempty"` // "" = auto (green/amber/red), else "#RRGGBB"
+	RatingRing      bool   `json:"ratingRing,omitempty"`
+	RatingRingPos   string `json:"ratingRingPos,omitempty"`   // "tl" | "tr" | "bl" | "br"
+	RatingRingColor string `json:"ratingRingColor,omitempty"` // "" = auto (green/amber/red), else "#RRGGBB"
 }
 
 // Default returns a Config populated with production defaults.
@@ -136,10 +135,9 @@ type raw struct {
 	Trending         *bool    `json:"trending"`
 	BackdropAsPoster *bool    `json:"backdropAsPoster"`
 	BackdropLogo     *bool    `json:"backdropLogo"`
-	RatingRing       *bool    `json:"ratingRing"`
-	RatingRingStyle  *string  `json:"ratingRingStyle"`
-	RatingRingPos    *string  `json:"ratingRingPos"`
-	RatingRingColor  *string  `json:"ratingRingColor"`
+	RatingRing      *bool   `json:"ratingRing"`
+	RatingRingPos   *string `json:"ratingRingPos"`
+	RatingRingColor *string `json:"ratingRingColor"`
 }
 
 // Parse deserializes a profile config JSON blob into a normalized Config.
@@ -242,14 +240,6 @@ func Parse(data json.RawMessage) Config {
 	if r.RatingRing != nil {
 		cfg.RatingRing = *r.RatingRing
 	}
-	if r.RatingRingStyle != nil {
-		switch strings.ToLower(strings.TrimSpace(*r.RatingRingStyle)) {
-		case "ring", "full":
-			cfg.RatingRingStyle = "ring"
-		case "compact", "wings":
-			cfg.RatingRingStyle = "compact"
-		}
-	}
 	if r.RatingRingPos != nil {
 		switch strings.ToLower(strings.TrimSpace(*r.RatingRingPos)) {
 		case "tl", "tr", "bl", "br":
@@ -286,12 +276,11 @@ func CacheKey(cfg Config) string {
 		AggregateBar     bool           `json:"aggregateBar"`
 		AggregateBarPos  string         `json:"aggregateBarPos"`
 		Trending         bool           `json:"trending"`
-		BackdropAsPoster bool           `json:"backdropAsPoster"`
-		BackdropLogo     bool           `json:"backdropLogo"`
-		RatingRing       bool           `json:"ratingRing"`
-		RatingRingStyle  string         `json:"ratingRingStyle"`
-		RatingRingPos    string         `json:"ratingRingPos"`
-		RatingRingColor  string         `json:"ratingRingColor"`
+		BackdropAsPoster bool   `json:"backdropAsPoster"`
+		BackdropLogo     bool   `json:"backdropLogo"`
+		RatingRing       bool   `json:"ratingRing"`
+		RatingRingPos    string `json:"ratingRingPos"`
+		RatingRingColor  string `json:"ratingRingColor"`
 	}
 	ratings := make([]string, len(cfg.Ratings))
 	copy(ratings, cfg.Ratings)
@@ -322,7 +311,6 @@ func CacheKey(cfg Config) string {
 		BackdropAsPoster: cfg.BackdropAsPoster,
 		BackdropLogo:     cfg.BackdropLogo,
 		RatingRing:       cfg.RatingRing,
-		RatingRingStyle:  cfg.RatingRingStyle,
 		RatingRingPos:    cfg.RatingRingPos,
 		RatingRingColor:  cfg.RatingRingColor,
 	}

--- a/internal/provider/tmdb.go
+++ b/internal/provider/tmdb.go
@@ -215,7 +215,7 @@ func (t *TMDB) fetchByTMDBID(ctx context.Context, mediaType, id string, opts Art
 		meta.BackdropURL = tmdbImageBase + backdropRes + backdropPath
 	}
 	if logoPath := selectImagePath(result.Images.Logos, "", lang, ""); logoPath != "" {
-		meta.LogoURL = tmdbImageBase + "/w500" + logoPath
+		meta.LogoURL = tmdbImageBase + "/w780" + logoPath
 	}
 	if result.VoteAverage > 0 {
 		meta.Ratings = []Rating{{

--- a/internal/render/output.go
+++ b/internal/render/output.go
@@ -52,7 +52,7 @@ func DimensionsForSize(mediaType, size string) Dimensions {
 	case "logo":
 		d = Dimensions{800, 200}
 	default:
-		d = Dimensions{580, 859}
+		d = Dimensions{780, 1170}
 	}
 	mult, ok := sizeMultipliers[size]
 	if !ok {

--- a/internal/render/output_test.go
+++ b/internal/render/output_test.go
@@ -21,11 +21,11 @@ func TestIsValidMediaType(t *testing.T) {
 
 func TestDimensionsFor(t *testing.T) {
 	cases := []struct{ mediaType string; w, h int }{
-		{"poster", 580, 859},
+		{"poster", 780, 1170},
 		{"backdrop", 1280, 720},
 		{"thumbnail", 320, 180},
 		{"logo", 800, 200},
-		{"unknown", 580, 859},
+		{"unknown", 780, 1170},
 	}
 	for _, tc := range cases {
 		d := DimensionsFor(tc.mediaType)
@@ -53,7 +53,7 @@ func TestPlaceholderPNGIsDeterministic(t *testing.T) {
 
 func TestPlaceholderPNGDecodesWithCorrectDimensions(t *testing.T) {
 	cases := []struct{ mediaType string; w, h int }{
-		{"poster", 580, 859},
+		{"poster", 780, 1170},
 		{"backdrop", 1280, 720},
 		{"thumbnail", 320, 180},
 		{"logo", 800, 200},
@@ -100,12 +100,12 @@ func TestDimensionsForSize(t *testing.T) {
 		mediaType, size string
 		wantW, wantH    int
 	}{
-		{"poster", "normal", 580, 859},
-		{"poster", "large", 870, 1289},
-		{"poster", "4k", 1740, 2577},
+		{"poster", "normal", 780, 1170},
+		{"poster", "large", 1170, 1755},
+		{"poster", "4k", 2340, 3510},
 		{"backdrop", "4k", 3840, 2160},
 		{"thumbnail", "large", 480, 270},
-		{"poster", "bogus", 580, 859},
+		{"poster", "bogus", 780, 1170},
 	}
 	for _, tc := range cases {
 		d := DimensionsForSize(tc.mediaType, tc.size)

--- a/web/components/configurator-client.tsx
+++ b/web/components/configurator-client.tsx
@@ -88,7 +88,7 @@ export function ConfiguratorClient() {
       providers: cfg.providers, aggregateBar: cfg.aggregateBar,
       aggregateBarPos: cfg.aggregateBarPos, trending: cfg.trending,
       backdropAsPoster: cfg.backdropAsPoster,
-      ratingRing: cfg.ratingRing, ratingRingStyle: cfg.ratingRingStyle,
+      ratingRing: cfg.ratingRing,
       ratingRingPos: cfg.ratingRingPos, ratingRingColor: cfg.ratingRingColor,
     }));
   }, []);

--- a/web/components/configurator-panels.tsx
+++ b/web/components/configurator-panels.tsx
@@ -6,7 +6,7 @@ import { fetchTemplates, type Template } from '@/lib/api';
 import type { ConfigState, UpdateConfigFn } from './configurator-types';
 import {
   LAYOUT_OPTIONS, RATING_OPTIONS, BADGE_STYLE_OPTIONS, BADGE_THEME_OPTIONS,
-  RING_STYLE_OPTIONS, RING_POS_OPTIONS,
+  RING_POS_OPTIONS,
 } from './configurator-types';
 
 // ── Template strip ────────────────────────────────────────────────────────────
@@ -135,7 +135,7 @@ export function RatingsPanel({ uid, config, onUpdate, onToggleRating }: RatingsP
           <>
             <div className="field">
               <span className="label" id={`${uid}-ring-label`}>Average ring</span>
-              <div className="opt-grid" style={{ gridTemplateColumns: '1fr 1fr 1fr' }} role="group" aria-labelledby={`${uid}-ring-label`}>
+              <div className="opt-grid" role="group" aria-labelledby={`${uid}-ring-label`}>
                 <button
                   className={`opt-btn${!config.ratingRing ? ' opt-btn--active' : ''}`}
                   onClick={() => onUpdate('ratingRing', false)}
@@ -143,16 +143,13 @@ export function RatingsPanel({ uid, config, onUpdate, onToggleRating }: RatingsP
                 >
                   Off
                 </button>
-                {RING_STYLE_OPTIONS.map(o => (
-                  <button
-                    key={o.id}
-                    className={`opt-btn${config.ratingRing && config.ratingRingStyle === o.id ? ' opt-btn--active' : ''}`}
-                    onClick={() => { onUpdate('ratingRing', true); onUpdate('ratingRingStyle', o.id); }}
-                    aria-pressed={config.ratingRing && config.ratingRingStyle === o.id}
-                  >
-                    {o.label}
-                  </button>
-                ))}
+                <button
+                  className={`opt-btn${config.ratingRing ? ' opt-btn--active' : ''}`}
+                  onClick={() => onUpdate('ratingRing', true)}
+                  aria-pressed={config.ratingRing}
+                >
+                  Ring
+                </button>
               </div>
             </div>
 

--- a/web/components/configurator-types.ts
+++ b/web/components/configurator-types.ts
@@ -83,11 +83,6 @@ export const GENRE_POS_OPTIONS = [
   { id: 'tr',      label: 'Top right'    },
 ] as const;
 
-export const RING_STYLE_OPTIONS = [
-  { id: 'ring',    label: 'Ring'  },
-  { id: 'compact', label: 'Wings' },
-] as const;
-
 export const RING_POS_OPTIONS = [
   { id: 'br', label: 'Bottom right' },
   { id: 'bl', label: 'Bottom left'  },
@@ -129,7 +124,6 @@ export interface ConfigState {
   trending: boolean;
   backdropAsPoster: boolean;
   ratingRing: boolean;
-  ratingRingStyle: string;
   ratingRingPos: string;
   ratingRingColor: string;
 }
@@ -154,7 +148,6 @@ export const DEFAULT_CONFIG: ConfigState = {
   trending: false,
   backdropAsPoster: false,
   ratingRing: false,
-  ratingRingStyle: 'ring',
   ratingRingPos: 'br',
   ratingRingColor: '',
 };


### PR DESCRIPTION
## Summary

- **Remove wings style**: Deleted `drawCompactWings`, `drawArcOnly`, `angleBetween` — only the circular progress ring remains. `RatingRingStyle` stripped from config, parser, cache key, and frontend. UI ring control simplified to On / Off.
- **Sharper fonts**: Base sizes raised from 14pt/11pt @ 72 DPI → 16pt/13pt @ 96 DPI across all badge text (value + label), including scaled variants for large/4K outputs.
- **Larger badges**: Icon size up from 17 → 20px; horizontal/vertical padding increased proportionally for more breathing room.
- **CatmullRom throughout**: `drawLogoScaled` (provider icons), main poster scaling (`resizeFit`), backdrop/logo scaling (`resizeFitSmart`, `resizeContain`) all switched from BiLinear/nearest-neighbour to CatmullRom for sharper edges.

## Test plan

- [ ] `go test ./...` passes (241 tests)
- [ ] Visual render check via `./scripts/visual-test.sh` — badges larger, text crisper, no wings element visible
- [ ] Ring still appears when enabled (circular progress only)
- [ ] Provider logos sharper in backdrop-as-poster mode
- [ ] Light and dark badge themes both readable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Updated image scaling to use higher-quality Catmull-Rom interpolation for clearer backdrops.
  * Refined rating badge typography and spacing for a more polished look.
  * Improved provider logo rendering with smoother scaling and more accurate transparency blending.
  * Simplified “Average ring” controls to only enable/disable the ring.
  * Increased TMDB logo resolution used for rendering and adjusted related output sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->