### PR TITLE
feat(animemap): add nattadasu supplement dataset to fill film/special gaps

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -92,10 +92,11 @@ func main() {
 	// Anime providers — public APIs, no key required. Wrapped with the anime
 	// ID mapper so IMDb/TMDB render IDs resolve to MAL/AniList/Kitsu IDs.
 	animeMapper := animemap.New(animemap.Options{
-		CacheDir:    cfg.CacheDir,
-		DatasetURL:  cfg.AnimeMapURL,
-		FallbackURL: cfg.AnimeMapFallbackURL,
-		TTL:         cfg.AnimeMapRefresh,
+		CacheDir:      cfg.CacheDir,
+		DatasetURL:    cfg.AnimeMapURL,
+		FallbackURL:   cfg.AnimeMapFallbackURL,
+		SupplementURL: cfg.AnimeMapSupplementURL,
+		TTL:           cfg.AnimeMapRefresh,
 	})
 	reg.Register(provider.NewAnimeMapped(provider.NewMALWithURL(cfg.JikanURL), animeMapper))
 	reg.Register(provider.NewAnimeMapped(provider.NewAniList(), animeMapper))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,14 +20,17 @@ type Config struct {
 	FanartAPIKey        string
 	TraktClientID       string
 	SIMKLClientID       string
-	IMDbDatasetDir      string                   // directory for cached IMDb dataset file; empty = disabled
-	JikanURL            string                   // override Jikan API base URL; empty = public api.jikan.moe
-	AnimeMapURL         string                   // override anime ID mapping dataset URL; empty = default
-	AnimeMapFallbackURL string                   // live anime mapping API base URL; "off" disables
-	AnimeMapRefresh     time.Duration            // anime mapping dataset refresh interval; 0 = default (7 days)
-	ProviderTTLs        map[string]time.Duration // per-provider TTL overrides; key = provider name
-	AdminKey            string                   // protects /api/admin/* routes
-	APIKey              string                   // if set, required on all render routes
+	IMDbDatasetDir      string // directory for cached IMDb dataset file; empty = disabled
+	JikanURL            string // override Jikan API base URL; empty = public api.jikan.moe
+	AnimeMapURL         string // override anime ID mapping dataset URL; empty = default
+	AnimeMapFallbackURL string // live anime mapping API base URL; "off" disables
+	// AnimeMapSupplementURL is the secondary anime mapping dataset (nattadasu);
+	// "" uses the built-in default, "off" disables it.
+	AnimeMapSupplementURL string
+	AnimeMapRefresh       time.Duration            // anime mapping dataset refresh interval; 0 = default (7 days)
+	ProviderTTLs          map[string]time.Duration // per-provider TTL overrides; key = provider name
+	AdminKey              string                   // protects /api/admin/* routes
+	APIKey                string                   // if set, required on all render routes
 }
 
 // loadProviderTTLs builds the per-provider TTL map.
@@ -83,25 +86,26 @@ func Load() Config {
 		}
 	}
 	return Config{
-		Address:             addr,
-		Version:             version,
-		DBPath:              dbPath,
-		CacheDir:            cacheDir,
-		CacheTTL:            cacheTTL,
-		TMDBAPIKey:          os.Getenv("XRDB_TMDB_API_KEY"),
-		TMDBReadToken:       os.Getenv("XRDB_TMDB_READ_TOKEN"),
-		MDBListAPIKey:       os.Getenv("XRDB_MDBLIST_API_KEY"),
-		OMDBAPIKey:          os.Getenv("XRDB_OMDB_API_KEY"),
-		FanartAPIKey:        os.Getenv("XRDB_FANART_API_KEY"),
-		TraktClientID:       os.Getenv("XRDB_TRAKT_CLIENT_ID"),
-		SIMKLClientID:       os.Getenv("XRDB_SIMKL_CLIENT_ID"),
-		IMDbDatasetDir:      os.Getenv("XRDB_IMDB_DATASET_DIR"),
-		JikanURL:            os.Getenv("XRDB_JIKAN_URL"),
-		AnimeMapURL:         os.Getenv("XRDB_ANIME_MAP_URL"),
-		AnimeMapFallbackURL: os.Getenv("XRDB_ANIME_MAP_FALLBACK_URL"),
-		AnimeMapRefresh:     animeMapRefresh,
-		ProviderTTLs:        loadProviderTTLs(cacheTTL),
-		AdminKey:            os.Getenv("XRDB_ADMIN_KEY"),
-		APIKey:              os.Getenv("XRDB_API_KEY"),
+		Address:               addr,
+		Version:               version,
+		DBPath:                dbPath,
+		CacheDir:              cacheDir,
+		CacheTTL:              cacheTTL,
+		TMDBAPIKey:            os.Getenv("XRDB_TMDB_API_KEY"),
+		TMDBReadToken:         os.Getenv("XRDB_TMDB_READ_TOKEN"),
+		MDBListAPIKey:         os.Getenv("XRDB_MDBLIST_API_KEY"),
+		OMDBAPIKey:            os.Getenv("XRDB_OMDB_API_KEY"),
+		FanartAPIKey:          os.Getenv("XRDB_FANART_API_KEY"),
+		TraktClientID:         os.Getenv("XRDB_TRAKT_CLIENT_ID"),
+		SIMKLClientID:         os.Getenv("XRDB_SIMKL_CLIENT_ID"),
+		IMDbDatasetDir:        os.Getenv("XRDB_IMDB_DATASET_DIR"),
+		JikanURL:              os.Getenv("XRDB_JIKAN_URL"),
+		AnimeMapURL:           os.Getenv("XRDB_ANIME_MAP_URL"),
+		AnimeMapFallbackURL:   os.Getenv("XRDB_ANIME_MAP_FALLBACK_URL"),
+		AnimeMapSupplementURL: os.Getenv("XRDB_ANIME_MAP_SUPPLEMENT_URL"),
+		AnimeMapRefresh:       animeMapRefresh,
+		ProviderTTLs:          loadProviderTTLs(cacheTTL),
+		AdminKey:              os.Getenv("XRDB_ADMIN_KEY"),
+		APIKey:                os.Getenv("XRDB_API_KEY"),
 	}
 }

--- a/internal/provider/animemap/animemap.go
+++ b/internal/provider/animemap/animemap.go
@@ -288,6 +288,16 @@ func (s *source) ensureLoaded() {
 	s.loading = ch
 	s.mu.Unlock()
 
+	// Always reset loading and unblock waiters — even if downloadAndStore
+	// panics — so a panic can't permanently wedge every future blocking caller
+	// on a channel that never closes.
+	defer func() {
+		s.mu.Lock()
+		s.loading = nil
+		close(ch)
+		s.mu.Unlock()
+	}()
+
 	err := s.downloadAndStore()
 
 	s.mu.Lock()
@@ -296,8 +306,6 @@ func (s *source) ensureLoaded() {
 			s.loaded = true
 		}
 	}
-	s.loading = nil
-	close(ch)
 	s.mu.Unlock()
 }
 

--- a/internal/provider/animemap/animemap.go
+++ b/internal/provider/animemap/animemap.go
@@ -126,6 +126,7 @@ type source struct {
 	loadedAt    time.Time
 	lastAttempt time.Time
 	refreshing  bool
+	loading     chan struct{} // non-nil while a blocking cold-load is in flight (single-flight)
 	byIMDb      map[string]indexed
 	byTMDBMovie map[int]indexed
 	byTMDBTV    map[int]indexed
@@ -251,15 +252,24 @@ func (s *source) lookupLocked(mediaType, id string) (IDs, bool) {
 // render latency never depends on the upstream host.
 func (s *source) ensureLoaded() {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	if !s.loaded {
 		if err := s.loadFromDiskLocked(); err == nil {
 			s.loaded = true
 		}
 	}
+	// A blocking cold-load is already in flight: wait for it instead of falling
+	// through to a lookup on empty indexes. This makes the first download a true
+	// single-flight for concurrent callers, honoring the blocking guarantee.
+	if !s.loaded && s.loading != nil {
+		ch := s.loading
+		s.mu.Unlock()
+		<-ch
+		return
+	}
 	stale := !s.loaded || time.Since(s.loadedAt) > s.ttl
 	if !stale || s.refreshing || time.Since(s.lastAttempt) < retryBackoff {
+		s.mu.Unlock()
 		return
 	}
 	s.lastAttempt = time.Now()
@@ -268,18 +278,27 @@ func (s *source) ensureLoaded() {
 		// source with no data yet (background initial download).
 		s.refreshing = true
 		go s.refresh()
+		s.mu.Unlock()
 		return
 	}
-	// Blocking source with no usable dataset at all: block this first caller on
-	// the download so the very first anime render can still succeed.
+	// Blocking source with no usable dataset at all: download synchronously so
+	// the very first anime render can still succeed, and publish a loading
+	// channel so concurrent callers wait on this same load.
+	ch := make(chan struct{})
+	s.loading = ch
 	s.mu.Unlock()
+
 	err := s.downloadAndStore()
+
 	s.mu.Lock()
 	if err == nil {
 		if err := s.loadFromDiskLocked(); err == nil {
 			s.loaded = true
 		}
 	}
+	s.loading = nil
+	close(ch)
+	s.mu.Unlock()
 }
 
 func (s *source) refresh() {

--- a/internal/provider/animemap/animemap.go
+++ b/internal/provider/animemap/animemap.go
@@ -3,8 +3,14 @@
 //
 // The primary source is the community-maintained Fribb/anime-lists dataset,
 // downloaded once and cached on disk so lookups are local and survive upstream
-// outages. Entries missing from the dataset fall back to a live mapping API
-// (arm.haglund.dev by default) with per-ID caching, including negative results.
+// outages. A secondary "supplement" source (nattadasu/animeApi) fills gaps the
+// primary misses — chiefly anime films, OVAs and specials whose IMDb/TMDB
+// linkage the Fribb lineage lacks. Entries missing from both datasets fall back
+// to a live mapping API (arm.haglund.dev by default) with per-ID caching,
+// including negative results.
+//
+// Supplement data (nattadasu/animeApi) is licensed ODbL v1.0 + DbCL v1.0;
+// attribution: https://github.com/nattadasu/animeApi.
 package animemap
 
 import (
@@ -41,8 +47,16 @@ const (
 	// DefaultFallbackURL is the live per-ID mapping API used for titles the
 	// dataset doesn't cover yet. Set to "off" in Options to disable.
 	DefaultFallbackURL = "https://arm.haglund.dev/api/v2"
+	// DefaultSupplementURL is nattadasu/animeApi's aggregated dataset (~32 MB).
+	// It is loaded as a secondary offline source for IMDb/TMDB titles the Fribb
+	// primary and the live fallback both miss (mostly films/OVAs/specials). Set
+	// to "off" in Options to disable. There is no public mirror large enough to
+	// serve this file, so it has none; the disk cache and non-blocking load
+	// keep it resilient to upstream outages.
+	DefaultSupplementURL = "https://raw.githubusercontent.com/nattadasu/animeApi/v3/database/animeapi.json"
 
 	datasetFileName    = "anime-map.json"
+	supplementFileName = "anime-map-supplement.json"
 	maxDatasetBytes    = 64 * 1024 * 1024
 	downloadTimeout    = 60 * time.Second
 	retryBackoff       = 5 * time.Minute
@@ -53,35 +67,26 @@ const (
 
 // Options configures a Mapper.
 type Options struct {
-	CacheDir    string        // directory for the cached dataset file (required)
-	DatasetURL  string        // override dataset URL (default Fribb anime-lists)
-	MirrorURL   string        // override mirror URL
-	FallbackURL string        // live mapping API base URL; "off" disables
-	TTL         time.Duration // dataset refresh interval (default 7 days)
-	HTTPClient  *http.Client  // override HTTP client (tests)
+	CacheDir            string        // directory for the cached dataset files (required)
+	DatasetURL          string        // override primary dataset URL (default Fribb anime-lists)
+	MirrorURL           string        // override primary mirror URL
+	FallbackURL         string        // live mapping API base URL; "off" disables
+	SupplementURL       string        // secondary dataset URL (default nattadasu); "off" disables
+	SupplementMirrorURL string        // optional mirror for the supplement (default none)
+	TTL                 time.Duration // dataset refresh interval (default 7 days)
+	HTTPClient          *http.Client  // override HTTP client (tests)
 }
 
-// Mapper resolves media IDs to anime-service IDs using a disk-cached dataset
+// Mapper resolves media IDs to anime-service IDs using disk-cached datasets
 // with a live API fallback. Safe for concurrent use.
 type Mapper struct {
-	datasetURL  string
-	mirrorURL   string
+	primary    *source // Fribb dataset (blocks first render until loaded)
+	supplement *source // nattadasu dataset; nil when disabled (best-effort, non-blocking)
+	httpClient *http.Client
+
 	fallbackURL string
-	path        string
-	ttl         time.Duration
-	httpClient  *http.Client
-
-	mu          sync.Mutex
-	loaded      bool
-	loadedAt    time.Time
-	lastAttempt time.Time
-	refreshing  bool
-	byIMDb      map[string]indexed
-	byTMDBMovie map[int]indexed
-	byTMDBTV    map[int]indexed
-
-	fbMu    sync.Mutex
-	fbCache map[string]fallbackEntry
+	fbMu        sync.Mutex
+	fbCache     map[string]fallbackEntry
 }
 
 // indexed pairs resolved IDs with a season rank so first-season entries win
@@ -97,7 +102,36 @@ type fallbackEntry struct {
 	expires time.Time
 }
 
-// New creates a Mapper. The dataset loads lazily on first Resolve.
+// datasetParser turns raw dataset bytes into the IMDb, TMDB-movie and TMDB-TV
+// indexes. Different sources carry different on-disk schemas but share this
+// index shape.
+type datasetParser func(data []byte) (imdb map[string]indexed, movie map[int]indexed, tv map[int]indexed, err error)
+
+// source is one disk-cached dataset (primary or supplement) with its own
+// indexes and refresh lifecycle. Safe for concurrent use.
+type source struct {
+	url        string
+	mirror     string
+	path       string
+	ttl        time.Duration
+	httpClient *http.Client
+	parse      datasetParser
+	// blocking makes the very first caller wait on the initial download so the
+	// first anime render can succeed. The supplement is non-blocking: when it
+	// has no data yet it downloads in the background and contributes once ready.
+	blocking bool
+
+	mu          sync.Mutex
+	loaded      bool
+	loadedAt    time.Time
+	lastAttempt time.Time
+	refreshing  bool
+	byIMDb      map[string]indexed
+	byTMDBMovie map[int]indexed
+	byTMDBTV    map[int]indexed
+}
+
+// New creates a Mapper. Datasets load lazily on first Resolve.
 func New(opts Options) *Mapper {
 	if opts.DatasetURL == "" {
 		opts.DatasetURL = DefaultDatasetURL
@@ -111,46 +145,80 @@ func New(opts Options) *Mapper {
 	if strings.EqualFold(opts.FallbackURL, "off") {
 		opts.FallbackURL = ""
 	}
+	if opts.SupplementURL == "" {
+		opts.SupplementURL = DefaultSupplementURL
+	}
+	if strings.EqualFold(opts.SupplementURL, "off") {
+		opts.SupplementURL = ""
+	}
 	if opts.TTL <= 0 {
 		opts.TTL = 7 * 24 * time.Hour
 	}
 	if opts.HTTPClient == nil {
 		opts.HTTPClient = &http.Client{Timeout: downloadTimeout}
 	}
-	return &Mapper{
-		datasetURL:  opts.DatasetURL,
-		mirrorURL:   opts.MirrorURL,
-		fallbackURL: strings.TrimRight(opts.FallbackURL, "/"),
-		path:        filepath.Join(opts.CacheDir, datasetFileName),
-		ttl:         opts.TTL,
+
+	m := &Mapper{
 		httpClient:  opts.HTTPClient,
+		fallbackURL: strings.TrimRight(opts.FallbackURL, "/"),
 		fbCache:     make(map[string]fallbackEntry),
+		primary: &source{
+			url:        opts.DatasetURL,
+			mirror:     opts.MirrorURL,
+			path:       filepath.Join(opts.CacheDir, datasetFileName),
+			ttl:        opts.TTL,
+			httpClient: opts.HTTPClient,
+			parse:      buildIndexes,
+			blocking:   true,
+		},
 	}
+	if opts.SupplementURL != "" {
+		m.supplement = &source{
+			url:        opts.SupplementURL,
+			mirror:     opts.SupplementMirrorURL,
+			path:       filepath.Join(opts.CacheDir, supplementFileName),
+			ttl:        opts.TTL,
+			httpClient: opts.HTTPClient,
+			parse:      buildSupplementIndexes,
+			blocking:   false,
+		}
+	}
+	return m
 }
 
 // Resolve maps a media ID (IMDb "tt…" or numeric TMDB) to anime-service IDs.
 // mediaType is the render type (poster/backdrop/…) and is only used to break
 // the movie/TV ambiguity of bare numeric TMDB IDs, mirroring the TMDB
-// provider's heuristic. Returns ok=false when the title isn't a known anime.
+// provider's heuristic. The primary dataset is consulted first, then the
+// supplement, then the live fallback. Returns ok=false when the title isn't a
+// known anime.
 func (m *Mapper) Resolve(ctx context.Context, mediaType, id string) (IDs, bool) {
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return IDs{}, false
 	}
-	m.ensureLoaded()
-
-	m.mu.Lock()
-	ids, ok := m.lookupLocked(mediaType, id)
-	m.mu.Unlock()
-	if ok {
+	if ids, ok := m.primary.lookup(mediaType, id); ok {
 		return ids, true
+	}
+	if m.supplement != nil {
+		if ids, ok := m.supplement.lookup(mediaType, id); ok {
+			return ids, true
+		}
 	}
 	return m.resolveFallback(ctx, id)
 }
 
-func (m *Mapper) lookupLocked(mediaType, id string) (IDs, bool) {
+// lookup loads the source if needed, then resolves id against its indexes.
+func (s *source) lookup(mediaType, id string) (IDs, bool) {
+	s.ensureLoaded()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lookupLocked(mediaType, id)
+}
+
+func (s *source) lookupLocked(mediaType, id string) (IDs, bool) {
 	if strings.HasPrefix(id, "tt") {
-		if e, ok := m.byIMDb[id]; ok {
+		if e, ok := s.byIMDb[id]; ok {
 			return e.ids, true
 		}
 		return IDs{}, false
@@ -162,9 +230,9 @@ func (m *Mapper) lookupLocked(mediaType, id string) (IDs, bool) {
 	// Bare numeric TMDB IDs are ambiguous between movie and TV; follow the
 	// TMDB provider's heuristic (backdrop ⇒ TV first) and try the other space
 	// second rather than failing.
-	first, second := m.byTMDBMovie, m.byTMDBTV
+	first, second := s.byTMDBMovie, s.byTMDBTV
 	if mediaType == "tv" || mediaType == "series" || mediaType == "backdrop" {
-		first, second = m.byTMDBTV, m.byTMDBMovie
+		first, second = s.byTMDBTV, s.byTMDBMovie
 	}
 	if e, ok := first[n]; ok {
 		return e.ids, true
@@ -176,100 +244,104 @@ func (m *Mapper) lookupLocked(mediaType, id string) (IDs, bool) {
 }
 
 // ensureLoaded loads the disk cache and downloads the dataset when missing or
-// stale. A missing dataset downloads synchronously (single-flight, throttled);
-// a stale-but-present dataset is served immediately and refreshed in the
-// background so render latency never depends on the upstream host.
-func (m *Mapper) ensureLoaded() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+// stale. For a blocking source a missing dataset downloads synchronously
+// (single-flight, throttled) so the first render can still succeed; for a
+// non-blocking source it downloads in the background. A stale-but-present
+// dataset is always served immediately and refreshed in the background so
+// render latency never depends on the upstream host.
+func (s *source) ensureLoaded() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	if !m.loaded {
-		if err := m.loadFromDiskLocked(); err == nil {
-			m.loaded = true
+	if !s.loaded {
+		if err := s.loadFromDiskLocked(); err == nil {
+			s.loaded = true
 		}
 	}
-	stale := !m.loaded || time.Since(m.loadedAt) > m.ttl
-	if !stale || m.refreshing || time.Since(m.lastAttempt) < retryBackoff {
+	stale := !s.loaded || time.Since(s.loadedAt) > s.ttl
+	if !stale || s.refreshing || time.Since(s.lastAttempt) < retryBackoff {
 		return
 	}
-	m.lastAttempt = time.Now()
-	if m.loaded {
-		m.refreshing = true
-		go m.refresh()
+	s.lastAttempt = time.Now()
+	if s.loaded || !s.blocking {
+		// Already have usable data (background refresh), or a non-blocking
+		// source with no data yet (background initial download).
+		s.refreshing = true
+		go s.refresh()
 		return
 	}
-	// No usable dataset at all: block this first caller on the download so
-	// the very first anime render can still succeed.
-	m.mu.Unlock()
-	err := m.downloadAndStore()
-	m.mu.Lock()
+	// Blocking source with no usable dataset at all: block this first caller on
+	// the download so the very first anime render can still succeed.
+	s.mu.Unlock()
+	err := s.downloadAndStore()
+	s.mu.Lock()
 	if err == nil {
-		if err := m.loadFromDiskLocked(); err == nil {
-			m.loaded = true
+		if err := s.loadFromDiskLocked(); err == nil {
+			s.loaded = true
 		}
 	}
 }
 
-func (m *Mapper) refresh() {
-	err := m.downloadAndStore()
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.refreshing = false
+func (s *source) refresh() {
+	err := s.downloadAndStore()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.refreshing = false
 	if err == nil {
-		if err := m.loadFromDiskLocked(); err == nil {
-			m.loaded = true
+		if err := s.loadFromDiskLocked(); err == nil {
+			s.loaded = true
 		}
 	}
 }
 
-func (m *Mapper) loadFromDiskLocked() error {
-	info, err := os.Stat(m.path)
+func (s *source) loadFromDiskLocked() error {
+	info, err := os.Stat(s.path)
 	if err != nil {
 		return err
 	}
-	data, err := os.ReadFile(m.path)
+	data, err := os.ReadFile(s.path)
 	if err != nil {
 		return err
 	}
-	imdb, movie, tv, err := buildIndexes(data)
+	imdb, movie, tv, err := s.parse(data)
 	if err != nil {
 		return err
 	}
-	m.byIMDb, m.byTMDBMovie, m.byTMDBTV = imdb, movie, tv
-	m.loadedAt = info.ModTime()
+	s.byIMDb, s.byTMDBMovie, s.byTMDBTV = imdb, movie, tv
+	s.loadedAt = info.ModTime()
 	return nil
 }
 
-func (m *Mapper) downloadAndStore() error {
-	data, err := m.fetchDataset(m.datasetURL)
-	if err != nil && m.mirrorURL != "" {
-		data, err = m.fetchDataset(m.mirrorURL)
+func (s *source) downloadAndStore() error {
+	data, err := s.fetchDataset(s.url)
+	if err != nil && s.mirror != "" {
+		data, err = s.fetchDataset(s.mirror)
 	}
 	if err != nil {
 		return err
 	}
 	// Validate before persisting so a bad body never replaces a good cache.
-	if _, _, _, err := buildIndexes(data); err != nil {
+	if _, _, _, err := s.parse(data); err != nil {
 		return fmt.Errorf("animemap: invalid dataset: %w", err)
 	}
-	if err := os.MkdirAll(filepath.Dir(m.path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
 		return err
 	}
-	tmp := m.path + ".tmp"
+	tmp := s.path + ".tmp"
 	if err := os.WriteFile(tmp, data, 0o644); err != nil {
 		return err
 	}
-	return os.Rename(tmp, m.path)
+	return os.Rename(tmp, s.path)
 }
 
-func (m *Mapper) fetchDataset(url string) ([]byte, error) {
+func (s *source) fetchDataset(url string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), downloadTimeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := m.httpClient.Do(req)
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("animemap: fetch dataset: %w", err)
 	}
@@ -420,6 +492,58 @@ func buildIndexes(data []byte) (map[string]indexed, map[int]indexed, map[int]ind
 	return imdb, movie, tv, nil
 }
 
+// supplementEntry mirrors the relevant fields of a nattadasu/animeApi row.
+// Numeric fields tolerate JSON null and string-encoded numbers via flexInt.
+type supplementEntry struct {
+	IMDb     string  `json:"imdb"`
+	TMDB     flexInt `json:"themoviedb"`
+	TMDBType string  `json:"themoviedb_type"`
+	MAL      flexInt `json:"myanimelist"`
+	AniList  flexInt `json:"anilist"`
+	Kitsu    flexInt `json:"kitsu"`
+}
+
+// buildSupplementIndexes parses the nattadasu/animeApi dataset. It indexes only
+// rows that carry an IMDb/TMDB key and at least one target ID, so the large raw
+// file collapses to the few thousand entries XRDB can actually use.
+func buildSupplementIndexes(data []byte) (map[string]indexed, map[int]indexed, map[int]indexed, error) {
+	var entries []supplementEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, nil, nil, err
+	}
+	if len(entries) == 0 {
+		return nil, nil, nil, fmt.Errorf("empty supplement dataset")
+	}
+	imdb := make(map[string]indexed)
+	movie := make(map[int]indexed)
+	tv := make(map[int]indexed)
+	for _, e := range entries {
+		ids := IDs{MAL: int(e.MAL), AniList: int(e.AniList), Kitsu: int(e.Kitsu)}
+		if ids.empty() {
+			continue
+		}
+		// The supplement has no season field; rank 0 means first-seen wins on
+		// the rare duplicate key, matching insert's tie-break.
+		item := indexed{ids: ids, rank: 0}
+		if strings.HasPrefix(e.IMDb, "tt") {
+			insert(imdb, e.IMDb, item)
+		}
+		if n := int(e.TMDB); n != 0 {
+			// Use the explicit type; an unknown/blank type goes to the movie
+			// index, and lookup's movie⇄TV fall-through still resolves it.
+			if strings.EqualFold(e.TMDBType, "tv") {
+				insert(tv, n, item)
+			} else {
+				insert(movie, n, item)
+			}
+		}
+	}
+	if len(imdb) == 0 && len(movie) == 0 && len(tv) == 0 {
+		return nil, nil, nil, fmt.Errorf("supplement dataset has no usable mappings")
+	}
+	return imdb, movie, tv, nil
+}
+
 // insert keeps the best-ranked entry per key: season-less or first-season
 // rows beat later seasons, and the first row wins ties (dataset order).
 func insert[K comparable](idx map[K]indexed, key K, item indexed) {
@@ -431,7 +555,7 @@ func insert[K comparable](idx map[K]indexed, key K, item indexed) {
 
 // ── live API fallback ────────────────────────────────────────────────────────
 
-// resolveFallback queries the live mapping API for IDs the dataset doesn't
+// resolveFallback queries the live mapping API for IDs the datasets don't
 // cover. Results — including misses — are cached so non-anime titles don't
 // trigger a network call on every render.
 func (m *Mapper) resolveFallback(ctx context.Context, id string) (IDs, bool) {

--- a/internal/provider/animemap/animemap_test.go
+++ b/internal/provider/animemap/animemap_test.go
@@ -23,17 +23,41 @@ const sampleDataset = `[
   {"type":"TV","anime-planet_id":"slug-only"}
 ]`
 
+// sampleSupplement mirrors the nattadasu/animeApi row shape (synthetic IDs).
+// The last two rows exercise primary precedence and a row with no target IDs.
+const sampleSupplement = `[
+  {"title":"Gap Movie","imdb":"tt5550000","themoviedb":555000,"themoviedb_type":"movie","myanimelist":5551,"anilist":5552,"kitsu":5553},
+  {"title":"Gap TV","imdb":"tt5560000","themoviedb":556000,"themoviedb_type":"tv","myanimelist":5561,"anilist":5562,"kitsu":5563},
+  {"title":"Overlap must not override primary","imdb":"tt0388629","themoviedb":37854,"themoviedb_type":"tv","myanimelist":999999,"anilist":999999,"kitsu":999999},
+  {"title":"no usable ids","imdb":"tt0000000"}
+]`
+
 func newTestMapper(t *testing.T, datasetURL, fallbackURL string) *Mapper {
 	t.Helper()
 	if fallbackURL == "" {
 		fallbackURL = "off"
 	}
 	return New(Options{
-		CacheDir:    t.TempDir(),
-		DatasetURL:  datasetURL,
-		MirrorURL:   datasetURL,
-		FallbackURL: fallbackURL,
+		CacheDir:      t.TempDir(),
+		DatasetURL:    datasetURL,
+		MirrorURL:     datasetURL,
+		FallbackURL:   fallbackURL,
+		SupplementURL: "off", // exercise the primary path in isolation
 	})
+}
+
+// eventually polls cond until it returns true or the deadline passes. The
+// supplement loads in the background, so gap lookups become available only
+// after its first download completes.
+func eventually(cond func() bool) bool {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
 }
 
 func TestResolveFromDataset(t *testing.T) {
@@ -81,7 +105,7 @@ func TestDatasetPersistedToDiskAndReused(t *testing.T) {
 	defer srv.Close()
 
 	dir := t.TempDir()
-	m1 := New(Options{CacheDir: dir, DatasetURL: srv.URL, MirrorURL: srv.URL, FallbackURL: "off"})
+	m1 := New(Options{CacheDir: dir, DatasetURL: srv.URL, MirrorURL: srv.URL, FallbackURL: "off", SupplementURL: "off"})
 	if _, ok := m1.Resolve(context.Background(), "poster", "tt0388629"); !ok {
 		t.Fatal("first mapper: expected mapping")
 	}
@@ -93,7 +117,7 @@ func TestDatasetPersistedToDiskAndReused(t *testing.T) {
 	}
 
 	// A fresh mapper over the same cache dir must not re-download.
-	m2 := New(Options{CacheDir: dir, DatasetURL: srv.URL, MirrorURL: srv.URL, FallbackURL: "off"})
+	m2 := New(Options{CacheDir: dir, DatasetURL: srv.URL, MirrorURL: srv.URL, FallbackURL: "off", SupplementURL: "off"})
 	if _, ok := m2.Resolve(context.Background(), "poster", "tt0388629"); !ok {
 		t.Fatal("second mapper: expected mapping from disk cache")
 	}
@@ -113,10 +137,11 @@ func TestMirrorUsedWhenPrimaryFails(t *testing.T) {
 	defer primary.Close()
 
 	m := New(Options{
-		CacheDir:    t.TempDir(),
-		DatasetURL:  primary.URL,
-		MirrorURL:   mirror.URL,
-		FallbackURL: "off",
+		CacheDir:      t.TempDir(),
+		DatasetURL:    primary.URL,
+		MirrorURL:     mirror.URL,
+		FallbackURL:   "off",
+		SupplementURL: "off",
 	})
 	if _, ok := m.Resolve(context.Background(), "poster", "tt0388629"); !ok {
 		t.Fatal("expected mapping via mirror")
@@ -139,7 +164,7 @@ func TestBadDatasetDoesNotReplaceGoodCache(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	m := New(Options{CacheDir: dir, DatasetURL: srv.URL, MirrorURL: srv.URL, FallbackURL: "off"})
+	m := New(Options{CacheDir: dir, DatasetURL: srv.URL, MirrorURL: srv.URL, FallbackURL: "off", SupplementURL: "off"})
 	if _, ok := m.Resolve(context.Background(), "poster", "tt0388629"); !ok {
 		t.Fatal("expected mapping from existing cache despite bad refresh body")
 	}
@@ -171,10 +196,11 @@ func TestFallbackResolvesAndCaches(t *testing.T) {
 	defer fallback.Close()
 
 	m := New(Options{
-		CacheDir:    t.TempDir(),
-		DatasetURL:  dataset.URL,
-		MirrorURL:   dataset.URL,
-		FallbackURL: fallback.URL,
+		CacheDir:      t.TempDir(),
+		DatasetURL:    dataset.URL,
+		MirrorURL:     dataset.URL,
+		FallbackURL:   fallback.URL,
+		SupplementURL: "off",
 	})
 
 	got, ok := m.Resolve(context.Background(), "poster", "tt7654321")
@@ -215,10 +241,107 @@ func TestNoDatasetNoFallbackResolvesNothing(t *testing.T) {
 	}
 }
 
+// TestSupplementFillsGapAndPrimaryWins verifies the supplement resolves IMDb/
+// TMDB ids the primary lacks, while the primary still wins on shared ids.
+func TestSupplementFillsGapAndPrimaryWins(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(sampleDataset))
+	}))
+	defer primary.Close()
+	supplement := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(sampleSupplement))
+	}))
+	defer supplement.Close()
+
+	m := New(Options{
+		CacheDir:      t.TempDir(),
+		DatasetURL:    primary.URL,
+		MirrorURL:     primary.URL,
+		SupplementURL: supplement.URL,
+		FallbackURL:   "off",
+	})
+
+	// Primary wins where both carry the id (supplement must not override it).
+	if got, ok := m.Resolve(context.Background(), "poster", "tt0388629"); !ok || got != (IDs{MAL: 21, AniList: 21, Kitsu: 12}) {
+		t.Fatalf("primary precedence: got (%+v,%v), want ({21 21 12}, true)", got, ok)
+	}
+
+	cases := []struct {
+		name, mediaType, id string
+		want                IDs
+	}{
+		{"supplement imdb movie", "poster", "tt5550000", IDs{MAL: 5551, AniList: 5552, Kitsu: 5553}},
+		{"supplement tmdb movie", "poster", "555000", IDs{MAL: 5551, AniList: 5552, Kitsu: 5553}},
+		{"supplement imdb tv", "poster", "tt5560000", IDs{MAL: 5561, AniList: 5562, Kitsu: 5563}},
+		{"supplement tmdb tv via backdrop", "backdrop", "556000", IDs{MAL: 5561, AniList: 5562, Kitsu: 5563}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !eventually(func() bool {
+				got, ok := m.Resolve(context.Background(), tc.mediaType, tc.id)
+				return ok && got == tc.want
+			}) {
+				got, ok := m.Resolve(context.Background(), tc.mediaType, tc.id)
+				t.Fatalf("supplement resolve %q: got (%+v,%v), want (%+v,true)", tc.id, got, ok, tc.want)
+			}
+		})
+	}
+
+	// A supplement row with no usable target IDs is not indexed.
+	if _, ok := m.Resolve(context.Background(), "poster", "tt0000000"); ok {
+		t.Error("expected no mapping for supplement row without target ids")
+	}
+}
+
+// TestSupplementDisabledWhenOff verifies SupplementURL:"off" never fetches the
+// supplement and never resolves supplement-only ids.
+func TestSupplementDisabledWhenOff(t *testing.T) {
+	var supHits atomic.Int32
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(sampleDataset))
+	}))
+	defer primary.Close()
+	supplement := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		supHits.Add(1)
+		_, _ = w.Write([]byte(sampleSupplement))
+	}))
+	defer supplement.Close()
+
+	m := New(Options{
+		CacheDir:      t.TempDir(),
+		DatasetURL:    primary.URL,
+		MirrorURL:     primary.URL,
+		SupplementURL: "off",
+		FallbackURL:   "off",
+	})
+
+	if _, ok := m.Resolve(context.Background(), "poster", "tt0388629"); !ok {
+		t.Fatal("expected primary mapping with supplement off")
+	}
+	for i := 0; i < 5; i++ {
+		if _, ok := m.Resolve(context.Background(), "poster", "tt5550000"); ok {
+			t.Fatal("supplement-only id resolved while supplement disabled")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if supHits.Load() != 0 {
+		t.Fatalf("supplement was fetched while disabled: %d hits", supHits.Load())
+	}
+}
+
 func TestBuildIndexesRejectsInvalid(t *testing.T) {
 	for _, bad := range []string{"", "{}", "[]", "not json"} {
 		if _, _, _, err := buildIndexes([]byte(bad)); err == nil {
 			t.Errorf("buildIndexes(%q): expected error", bad)
+		}
+	}
+}
+
+func TestBuildSupplementIndexesRejectsInvalid(t *testing.T) {
+	// Last case parses but yields no usable mappings (no target ids).
+	for _, bad := range []string{"", "{}", "[]", "not json", `[{"title":"x","imdb":"tt0000000"}]`} {
+		if _, _, _, err := buildSupplementIndexes([]byte(bad)); err == nil {
+			t.Errorf("buildSupplementIndexes(%q): expected error", bad)
 		}
 	}
 }

--- a/internal/provider/animemap/animemap_test.go
+++ b/internal/provider/animemap/animemap_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -58,6 +60,21 @@ func eventually(cond func() bool) bool {
 		time.Sleep(10 * time.Millisecond)
 	}
 	return cond()
+}
+
+// roundTripperFunc adapts a function to http.RoundTripper for instrumenting
+// outbound requests in tests.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func mustHost(t *testing.T, rawURL string) string {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse %q: %v", rawURL, err)
+	}
+	return u.Host
 }
 
 func TestResolveFromDataset(t *testing.T) {
@@ -296,16 +313,21 @@ func TestSupplementFillsGapAndPrimaryWins(t *testing.T) {
 // TestSupplementDisabledWhenOff verifies SupplementURL:"off" never fetches the
 // supplement and never resolves supplement-only ids.
 func TestSupplementDisabledWhenOff(t *testing.T) {
-	var supHits atomic.Int32
 	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(sampleDataset))
 	}))
 	defer primary.Close()
-	supplement := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		supHits.Add(1)
-		_, _ = w.Write([]byte(sampleSupplement))
-	}))
-	defer supplement.Close()
+
+	// Instrument the client to prove no request reaches anything but the
+	// primary while the supplement is disabled.
+	primaryHost := mustHost(t, primary.URL)
+	var nonPrimary atomic.Int32
+	client := &http.Client{Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Host != primaryHost {
+			nonPrimary.Add(1)
+		}
+		return http.DefaultTransport.RoundTrip(r)
+	})}
 
 	m := New(Options{
 		CacheDir:      t.TempDir(),
@@ -313,19 +335,63 @@ func TestSupplementDisabledWhenOff(t *testing.T) {
 		MirrorURL:     primary.URL,
 		SupplementURL: "off",
 		FallbackURL:   "off",
+		HTTPClient:    client,
 	})
 
 	if _, ok := m.Resolve(context.Background(), "poster", "tt0388629"); !ok {
 		t.Fatal("expected primary mapping with supplement off")
 	}
+	// A supplement-only id never resolves while the supplement is disabled.
 	for i := 0; i < 5; i++ {
 		if _, ok := m.Resolve(context.Background(), "poster", "tt5550000"); ok {
 			t.Fatal("supplement-only id resolved while supplement disabled")
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	if supHits.Load() != 0 {
-		t.Fatalf("supplement was fetched while disabled: %d hits", supHits.Load())
+	if n := nonPrimary.Load(); n != 0 {
+		t.Fatalf("unexpected non-primary outbound requests while supplement disabled: %d", n)
+	}
+}
+
+// TestPrimaryColdLoadIsSingleFlight verifies that concurrent first callers wait
+// for the primary's blocking cold-load instead of falling through, and that the
+// dataset is downloaded only once.
+func TestPrimaryColdLoadIsSingleFlight(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		time.Sleep(150 * time.Millisecond) // simulate a slow cold download
+		_, _ = w.Write([]byte(sampleDataset))
+	}))
+	defer srv.Close()
+
+	m := New(Options{
+		CacheDir:      t.TempDir(),
+		DatasetURL:    srv.URL,
+		MirrorURL:     srv.URL,
+		FallbackURL:   "off",
+		SupplementURL: "off",
+	})
+
+	const n = 8
+	var wg sync.WaitGroup
+	var resolved atomic.Int32
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			if _, ok := m.Resolve(context.Background(), "poster", "tt0388629"); ok {
+				resolved.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := resolved.Load(); got != n {
+		t.Fatalf("expected all %d concurrent cold-start callers to resolve, got %d", n, got)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("expected single-flight download (1 hit), got %d", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a secondary offline anime-ID dataset (**nattadasu/animeApi**) layered *behind* the existing Fribb primary, so IMDb/TMDB ids that neither the primary dataset nor the live ARM fallback can resolve now map to MAL/AniList/Kitsu. The gap is concentrated in anime **films, OVAs and specials**.

**Why (measured coverage of the current Fribb + ARM stack):**
- **IMDb:** 681 ids resolvable by nattadasu but absent from Fribb; a 25-id sample of those was resolved by the ARM fallback **0/25**.
- **TMDB:** ~950 ids absent from Fribb; **0/20** sampled resolved by ARM.
- Examples now resolving: Fate/stay night Heaven's Feel (`tt4054952` → MAL 25537), Gundam Hathaway (`tmdb 910850` → MAL 38716), One Piece: Heart of Gold, Death Note Rewrite, Ajin Part 3.

**Design:**
- Refactored the per-dataset download/cache/index lifecycle into a reusable `source` type.
- Primary (Fribb) blocks the first render until loaded (unchanged); supplement (nattadasu) loads in the **background**, best-effort and non-fatal — never adds render latency.
- Lookup order: **primary → supplement → live fallback**. The primary's season-aware disambiguation still wins on shared ids (supplement never overrides).
- Supplement uses the GitHub-raw dataset, disk-cached exactly like the primary — **no hosted-API dependency**. (The hosted `animeapi.my.id` just 302-redirects to the same raw file, and jsDelivr 404s on the 32 MB size, so there is no independent mirror; disk cache + non-blocking load cover outages.)
- Config: `XRDB_ANIME_MAP_SUPPLEMENT_URL` (`off` disables), **enabled by default**.
- Licensing/attribution: nattadasu/animeApi data is ODbL v1.0 + DbCL v1.0 (noted in the package doc).

**Trade-off:** the raw supplement file is ~32 MB (vs Fribb's ~6 MB) but collapses to ~6k IMDb + ~7k TMDB usable rows; only those are retained. Fits the existing 64 MB download cap.

## Test plan

- [x] `go build ./...` and `go vet` clean
- [x] `go test ./...` — **253 passing** across 18 packages
- [x] `go test -race ./internal/provider/animemap/` — clean (new background-load goroutine path)
- [x] New unit tests: supplement fills IMDb/TMDB gaps; primary precedence on shared ids; `SupplementURL:"off"` disables both fetch and resolution; supplement-parser input validation
- [x] Validated `buildSupplementIndexes` against the **real 32 MB** nattadasu file (throwaway test, not committed): 6,247 IMDb / 2,832 movie / 4,160 TV indexed; all sampled gap titles resolved to correct ids

**Risk:** `detect_changes` flags the internal `Resolve`/`ensureLoaded` flow as high blast-radius because this is an internal refactor; mitigated by unchanged public signatures (`New`, `Resolve`, `IDs`) and the full green suite incl. `-race`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional supplementary offline anime mapping source to fill gaps in the primary dataset’s IMDb/TMDB matches.
  * Added configuration for the supplementary dataset (including a mirror URL) and support for disabling it via environment settings.
* **Bug Fixes**
  * Supplement mappings are applied before the live fallback, improving match coverage.
  * When both primary and supplementary sources provide results, primary takes precedence.
* **Tests**
  * Added coverage for supplement indexing, handling invalid supplement payloads, and ensuring the supplement is not contacted when disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->