### PR TITLE
feat(trending): configurable badge style with vector trend-up arrow

### DIFF
--- a/internal/compose/badge_draw.go
+++ b/internal/compose/badge_draw.go
@@ -157,37 +157,146 @@ func fitRect(srcW, srcH int, dst image.Rectangle) image.Rectangle {
 	return image.Rect(x, y, x+w, y+h)
 }
 
-// fillFlame draws a small upward flame/teardrop: a point at the apex (cx, topY)
-// tapering down to a rounded base of half-width halfW whose bottom sits at
-// topY+height. Used as the "trending" accent.
-func fillFlame(dst *image.NRGBA, cx, topY, halfW, height int, c color.NRGBA) {
-	if height <= 0 || halfW <= 0 {
+// ptf is a floating-point point used for vector glyph paths.
+type ptf struct{ x, y float64 }
+
+// distToSegment returns the distance from (px, py) to the line segment a→b.
+func distToSegment(px, py float64, a, b ptf) float64 {
+	vx, vy := b.x-a.x, b.y-a.y
+	wx, wy := px-a.x, py-a.y
+	seg2 := vx*vx + vy*vy
+	t := 0.0
+	if seg2 > 0 {
+		t = (wx*vx + wy*vy) / seg2
+		if t < 0 {
+			t = 0
+		} else if t > 1 {
+			t = 1
+		}
+	}
+	dx := px - (a.x + t*vx)
+	dy := py - (a.y + t*vy)
+	return math.Sqrt(dx*dx + dy*dy)
+}
+
+// strokePolyline draws an anti-aliased thick polyline through pts. Joints and
+// caps are rounded (the fill is the half-width neighbourhood of the path), so
+// it stays crisp at small sizes. halfW is the half stroke width in pixels.
+func strokePolyline(dst *image.NRGBA, pts []ptf, halfW float64, c color.NRGBA) {
+	if len(pts) < 2 || halfW <= 0 {
 		return
 	}
-	r := float64(halfW)
-	apex := float64(topY)
-	// Centre of the rounded base, placed so the base bottom touches topY+height.
-	cyc := float64(topY+height) - r
-	if cyc <= apex {
-		cyc = apex + 1
+	minX, minY := math.Inf(1), math.Inf(1)
+	maxX, maxY := math.Inf(-1), math.Inf(-1)
+	for _, p := range pts {
+		minX, maxX = math.Min(minX, p.x), math.Max(maxX, p.x)
+		minY, maxY = math.Min(minY, p.y), math.Max(maxY, p.y)
 	}
-	for y := 0; y < height; y++ {
-		py := float64(topY + y)
-		var hw float64
+	pad := halfW + 1
+	x0, x1 := int(math.Floor(minX-pad)), int(math.Ceil(maxX+pad))
+	y0, y1 := int(math.Floor(minY-pad)), int(math.Ceil(maxY+pad))
+	for y := y0; y <= y1; y++ {
+		for x := x0; x <= x1; x++ {
+			px, py := float64(x)+0.5, float64(y)+0.5
+			d := math.Inf(1)
+			for i := 0; i+1 < len(pts); i++ {
+				if dd := distToSegment(px, py, pts[i], pts[i+1]); dd < d {
+					d = dd
+				}
+			}
+			cov := halfW + 0.5 - d
+			if cov <= 0 {
+				continue
+			}
+			if cov > 1 {
+				cov = 1
+			}
+			blendPixel(dst, x, y, color.NRGBA{R: c.R, G: c.G, B: c.B, A: uint8(float64(c.A) * cov)})
+		}
+	}
+}
+
+// fillTrendArrow draws the canonical "trending up" glyph — a rising zig-zag
+// line ending in a corner arrowhead at the top-right — inside the w×h box whose
+// top-left is (x, y). Stroke half-width is halfW. Reads instantly as "trending"
+// and stays sharp where a small filled flame turns to mush.
+func fillTrendArrow(dst *image.NRGBA, x, y, w, h int, halfW float64, c color.NRGBA) {
+	p := func(nx, ny float64) ptf {
+		return ptf{x: float64(x) + nx*float64(w), y: float64(y) + ny*float64(h)}
+	}
+	// Stock-chart wiggle up to the tip at the top-right corner.
+	strokePolyline(dst, []ptf{p(0.05, 0.74), p(0.40, 0.40), p(0.56, 0.56), p(0.93, 0.16)}, halfW, c)
+	// Corner arrowhead: one arm left, one arm down, meeting at the tip.
+	strokePolyline(dst, []ptf{p(0.62, 0.16), p(0.93, 0.16), p(0.93, 0.47)}, halfW, c)
+}
+
+// lighten blends c toward white by fraction f (0..1), preserving alpha.
+func lighten(c color.NRGBA, f float64) color.NRGBA {
+	mix := func(v uint8) uint8 {
+		nv := float64(v) + (255-float64(v))*f
+		if nv > 255 {
+			nv = 255
+		}
+		return uint8(nv)
+	}
+	return color.NRGBA{R: mix(c.R), G: mix(c.G), B: mix(c.B), A: c.A}
+}
+
+// flameTongue fills one asymmetric flame tongue with horizontal anti-aliasing.
+// apexY is the tip, r the base half-width, height the full height. lean curls
+// the tip sideways (strongest near the tip); tipPow controls tip sharpness
+// (higher = sharper). Used by fillFlameSharp to stack an inner + outer flame.
+func flameTongue(dst *image.NRGBA, cx, apexY, r, height, lean, tipPow float64, c color.NRGBA) {
+	cyc := apexY + height - r // centre of the rounded base
+	if cyc <= apexY {
+		cyc = apexY + 1
+	}
+	for y := int(math.Floor(apexY)); y < int(math.Ceil(apexY+height)); y++ {
+		py := float64(y) + 0.5
+		if py < apexY {
+			continue
+		}
+		var hw, tt float64
 		if py <= cyc {
-			// Upper taper: 0 at the apex, growing convexly to r at the base.
-			t := (py - apex) / (cyc - apex)
-			hw = r * math.Pow(t, 0.7)
+			tt = (py - apexY) / (cyc - apexY)
+			hw = r * math.Pow(tt, tipPow)
 		} else {
-			// Rounded base.
-			dy := py - cyc
-			if dy < r {
+			tt = 1
+			if dy := py - cyc; dy < r {
 				hw = math.Sqrt(r*r - dy*dy)
 			}
 		}
-		ihw := int(hw + 0.5)
-		for x := cx - ihw; x <= cx+ihw; x++ {
-			blendPixel(dst, x, topY+y, c)
+		if hw < 0.4 {
+			continue
+		}
+		center := cx + lean*r*math.Sin((1-tt)*1.6) // curl, strongest at the tip
+		left, right := center-hw, center+hw
+		for x := int(math.Floor(left)); x < int(math.Ceil(right)); x++ {
+			cov := math.Min(float64(x)+1, right) - math.Max(float64(x), left)
+			if cov <= 0 {
+				continue
+			}
+			if cov > 1 {
+				cov = 1
+			}
+			blendPixel(dst, x, y, color.NRGBA{R: c.R, G: c.G, B: c.B, A: uint8(float64(c.A) * cov)})
 		}
 	}
+}
+
+// fillFlameSharp draws a stylized flame: an asymmetric tongue with a curled,
+// sharp tip over a lighter inner flame, so it reads as fire rather than a plain
+// teardrop. cx is the base centre, topY the apex, halfW the base half-width.
+func fillFlameSharp(dst *image.NRGBA, cx, topY, halfW, height int, c color.NRGBA) {
+	if height <= 0 || halfW <= 0 {
+		return
+	}
+	fcx, ftop := float64(cx), float64(topY)
+	fhw, fh := float64(halfW), float64(height)
+	// Outer flame: pronounced rightward hook at a sharp tip breaks the
+	// symmetric-teardrop read.
+	flameTongue(dst, fcx, ftop, fhw, fh, 0.58, 1.05, c)
+	// Hot core: large, bright, lifted — the bright inner flame is what sells
+	// "fire" rather than "water drop".
+	flameTongue(dst, fcx+fhw*0.20, ftop+fh*0.30, fhw*0.58, fh*0.64, 0.40, 1.15, lighten(c, 0.74))
 }

--- a/internal/compose/badge_overlay.go
+++ b/internal/compose/badge_overlay.go
@@ -691,10 +691,60 @@ func drawAggregateBar(base *image.NRGBA, ratings []provider.Rating, cfg imagecon
 
 // ── Trending badge ────────────────────────────────────────────────────────────
 
+// trendingStyle selects the composition of the trending badge: which accent
+// glyph it carries and whether the "TRENDING" wordmark is shown.
+type trendingStyle int
+
+const (
+	trendingArrowWord trendingStyle = iota // ↗ rising arrow + TRENDING
+	trendingFlameWord                      // flame + TRENDING
+	trendingWordOnly                       // TRENDING only
+	trendingArrowOnly                      // ↗ rising arrow only
+	trendingFlameOnly                      // flame only
+)
+
+// defaultTrendingStyle is the production composition for the trending badge.
+const defaultTrendingStyle = trendingArrowWord
+
+// trendingAccent is the warm orange used for the badge's glyph and hairline.
+var trendingAccent = color.NRGBA{R: 255, G: 126, B: 42, A: 255}
+
+func (t trendingStyle) hasIcon() bool { return t != trendingWordOnly }
+func (t trendingStyle) hasLabel() bool {
+	return t != trendingArrowOnly && t != trendingFlameOnly
+}
+func (t trendingStyle) isArrow() bool {
+	return t == trendingArrowWord || t == trendingArrowOnly
+}
+
+// trendingStyleFromConfig maps the imageconfig enum to the internal draw style,
+// falling back to the arrow+word default for empty or unknown values.
+func trendingStyleFromConfig(s imageconfig.TrendingStyle) trendingStyle {
+	switch s {
+	case imageconfig.TrendingFlameWord:
+		return trendingFlameWord
+	case imageconfig.TrendingWord:
+		return trendingWordOnly
+	case imageconfig.TrendingArrow:
+		return trendingArrowOnly
+	case imageconfig.TrendingFlame:
+		return trendingFlameOnly
+	default:
+		return trendingArrowWord
+	}
+}
+
 // drawTrendingBadge draws a premium "TRENDING" pill at the top-left corner: a
-// warm vertical gradient capsule with a drawn up-arrow glyph, bold label, and a
-// soft drop shadow. Placed via occ so it never overlaps other overlays.
+// dark frosted capsule with a warm accent glyph, bold label, and a soft drop
+// shadow. Placed via occ so it never overlaps other overlays.
 func drawTrendingBadge(base *image.NRGBA, scale float64, occ *occupancy) {
+	drawTrendingBadgeStyled(base, scale, occ, defaultTrendingStyle)
+}
+
+// drawTrendingBadgeStyled renders the trending badge in the given composition.
+// The public drawTrendingBadge wraps it with defaultTrendingStyle; the extra
+// seam lets the visual-preview harness render every option from one code path.
+func drawTrendingBadgeStyled(base *image.NRGBA, scale float64, occ *occupancy, style trendingStyle) {
 	ensureFaces()
 	face := badgeFaceFor(scale)
 	if face == nil {
@@ -714,9 +764,30 @@ func drawTrendingBadge(base *image.NRGBA, scale float64, occ *occupancy) {
 	ascent := fm.Ascent.Ceil()
 	descent := fm.Descent.Ceil()
 	bh := padY*2 + ascent + descent
-	iconW := s(12)
-	tw := textWidth(face, label)
-	bw := padX*2 + iconW + iconGap + tw
+	glyphH := ascent
+
+	// The arrow reads best in a near-square box; the flame is narrower.
+	iconW := 0
+	if style.hasIcon() {
+		if style.isArrow() {
+			iconW = int(float64(glyphH)*0.92 + 0.5)
+		} else {
+			iconW = s(12)
+		}
+	}
+	tw := 0
+	if style.hasLabel() {
+		tw = textWidth(face, label)
+	}
+
+	bw := padX * 2
+	if style.hasIcon() {
+		bw += iconW
+	}
+	if style.hasIcon() && style.hasLabel() {
+		bw += iconGap
+	}
+	bw += tw
 	radius := bh / 2 // full capsule
 
 	r := occ.place("tl", bw, bh, edgeX, edgeY, s(7))
@@ -729,17 +800,27 @@ func drawTrendingBadge(base *image.NRGBA, scale float64, occ *occupancy) {
 	fillRoundedRect(base, r, radius, color.NRGBA{R: 18, G: 20, B: 26, A: 233})
 	drawRectBorder(base, r, radius, color.NRGBA{R: 255, G: 150, B: 92, A: 66}) // warm hairline
 
-	// Warm flame accent, vertically centered to the cap height.
-	flame := color.NRGBA{R: 255, G: 126, B: 42, A: 255}
-	glyphH := ascent
+	// Warm accent glyph, vertically centered to the cap height.
 	ax := r.Min.X + padX
 	atop := r.Min.Y + (bh-glyphH)/2
-	fillFlame(base, ax+iconW/2, atop, iconW/2, glyphH, flame)
+	if style.hasIcon() {
+		if style.isArrow() {
+			halfW := math.Max(1.1, float64(glyphH)/8.5)
+			fillTrendArrow(base, ax, atop, iconW, glyphH, halfW, trendingAccent)
+		} else {
+			fillFlameSharp(base, ax+iconW/2, atop, iconW/2, glyphH, trendingAccent)
+		}
+	}
 
 	// Label in a warm off-white.
-	tx := ax + iconW + iconGap
-	ty := r.Min.Y + padY + ascent
-	drawText(base, face, tx, ty, color.NRGBA{R: 255, G: 244, B: 238, A: 255}, label)
+	if style.hasLabel() {
+		tx := ax
+		if style.hasIcon() {
+			tx += iconW + iconGap
+		}
+		ty := r.Min.Y + padY + ascent
+		drawText(base, face, tx, ty, color.NRGBA{R: 255, G: 244, B: 238, A: 255}, label)
+	}
 }
 
 // ── Average rating ring ───────────────────────────────────────────────────────

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -206,7 +206,7 @@ func (p *Pipeline) Render(ctx context.Context, req Request) (*Result, error) {
 		drawAggregateBar(composed, allRatings, req.Config)
 	}
 	if req.Config.Trending {
-		drawTrendingBadge(composed, scale, occ)
+		drawTrendingBadgeStyled(composed, scale, occ, trendingStyleFromConfig(req.Config.TrendingStyle))
 	}
 	if req.Config.RatingRing {
 		drawAverageRatingRing(composed, allRatings, req.Config, scale, occ)

--- a/internal/compose/trending_preview_test.go
+++ b/internal/compose/trending_preview_test.go
@@ -30,13 +30,20 @@ func TestTrendingStyles(t *testing.T) {
 	const scale = 2.0
 	const cardW, cardH = 780, 112
 
+	seen := map[[4]uint64]string{}
 	for _, tc := range trendingStyleCases {
 		card := image.NewNRGBA(image.Rect(0, 0, cardW, cardH))
 		paintBackdropGradient(card)
 		before := clonePixels(card)
 		drawTrendingBadgeStyled(card, scale, newOccupancy(card.Bounds()), tc.style)
-		if clonePixels(card) == before {
+		after := clonePixels(card)
+		if after == before {
 			t.Errorf("trending style %q drew nothing", tc.caption)
+		}
+		if prev, ok := seen[after]; ok {
+			t.Errorf("trending style %q rendered identically to %q", tc.caption, prev)
+		} else {
+			seen[after] = tc.caption
 		}
 	}
 

--- a/internal/compose/trending_preview_test.go
+++ b/internal/compose/trending_preview_test.go
@@ -1,0 +1,102 @@
+package compose
+
+import (
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"testing"
+)
+
+// trendingStyleCases enumerates every trending badge composition for both the
+// coverage assertions and the optional visual sheet.
+var trendingStyleCases = []struct {
+	caption string
+	style   trendingStyle
+}{
+	{"A - rising arrow + word  (default)", trendingArrowWord},
+	{"B - flame + word", trendingFlameWord},
+	{"C - word only", trendingWordOnly},
+	{"D - rising arrow only", trendingArrowOnly},
+	{"E - flame only", trendingFlameOnly},
+}
+
+// TestTrendingStyles asserts that every trending badge style actually draws,
+// and — when TRENDING_OUT names a path — also writes a comparison PNG so the
+// design can be eyeballed:
+//
+//	TRENDING_OUT=/path/sheet.png go test ./internal/compose -run TestTrendingStyles
+func TestTrendingStyles(t *testing.T) {
+	const scale = 2.0
+	const cardW, cardH = 780, 112
+
+	for _, tc := range trendingStyleCases {
+		card := image.NewNRGBA(image.Rect(0, 0, cardW, cardH))
+		paintBackdropGradient(card)
+		before := clonePixels(card)
+		drawTrendingBadgeStyled(card, scale, newOccupancy(card.Bounds()), tc.style)
+		if clonePixels(card) == before {
+			t.Errorf("trending style %q drew nothing", tc.caption)
+		}
+	}
+
+	out := os.Getenv("TRENDING_OUT")
+	if out == "" {
+		return
+	}
+
+	ensureFaces()
+	capFace := labelFaceFor(1.0) // small annotation text, independent of badge scale
+	sheet := image.NewNRGBA(image.Rect(0, 0, cardW, cardH*len(trendingStyleCases)))
+	for i, tc := range trendingStyleCases {
+		card := image.NewNRGBA(image.Rect(0, 0, cardW, cardH))
+		paintBackdropGradient(card)
+		drawTrendingBadgeStyled(card, scale, newOccupancy(card.Bounds()), tc.style)
+		if capFace != nil {
+			drawText(card, capFace, 350, cardH/2+capFace.Metrics().Ascent.Ceil()/2-4,
+				color.NRGBA{R: 152, G: 160, B: 172, A: 255}, tc.caption)
+		}
+		blit(sheet, card, 0, i*cardH)
+		for x := 0; x < cardW; x++ { // 1px divider between cards
+			sheet.SetNRGBA(x, (i+1)*cardH-1, color.NRGBA{R: 0, G: 0, B: 0, A: 120})
+		}
+	}
+
+	f, err := os.Create(out)
+	if err != nil {
+		t.Fatalf("create %s: %v", out, err)
+	}
+	defer f.Close()
+	if err := png.Encode(f, sheet); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	t.Logf("wrote %s (%dx%d)", out, sheet.Bounds().Dx(), sheet.Bounds().Dy())
+}
+
+// paintBackdropGradient fills img with a dark blue-grey vertical gradient that
+// approximates a poster backdrop, so the frosted capsule reads correctly.
+func paintBackdropGradient(img *image.NRGBA) {
+	b := img.Bounds()
+	top := [3]float64{29, 41, 56}
+	bot := [3]float64{14, 20, 29}
+	h := float64(b.Dy())
+	for y := b.Min.Y; y < b.Max.Y; y++ {
+		t := float64(y-b.Min.Y) / h
+		r := uint8(top[0] + (bot[0]-top[0])*t)
+		g := uint8(top[1] + (bot[1]-top[1])*t)
+		bl := uint8(top[2] + (bot[2]-top[2])*t)
+		for x := b.Min.X; x < b.Max.X; x++ {
+			img.SetNRGBA(x, y, color.NRGBA{R: r, G: g, B: bl, A: 255})
+		}
+	}
+}
+
+// blit copies src onto dst with its top-left at (ox, oy).
+func blit(dst, src *image.NRGBA, ox, oy int) {
+	sb := src.Bounds()
+	for y := sb.Min.Y; y < sb.Max.Y; y++ {
+		for x := sb.Min.X; x < sb.Max.X; x++ {
+			dst.SetNRGBA(ox+x, oy+y, src.NRGBAAt(x, y))
+		}
+	}
+}

--- a/internal/imageconfig/config.go
+++ b/internal/imageconfig/config.go
@@ -69,32 +69,45 @@ const (
 	LayoutNone      RatingsLayout = "none"
 )
 
+// TrendingStyle controls the composition of the trending badge: which accent
+// glyph it carries and whether the "TRENDING" wordmark is shown.
+type TrendingStyle string
+
+const (
+	TrendingArrowWord TrendingStyle = "arrow-word" // rising arrow + TRENDING
+	TrendingFlameWord TrendingStyle = "flame-word" // flame + TRENDING
+	TrendingWord      TrendingStyle = "word"       // TRENDING only
+	TrendingArrow     TrendingStyle = "arrow"      // rising arrow only
+	TrendingFlame     TrendingStyle = "flame"      // flame only
+)
+
 // Config is the canonical, normalized render config for a media request.
 // All fields carry explicit defaults; zero values are never used in render logic.
 type Config struct {
-	Size              MediaSize      `json:"size"`
-	ArtworkSource     ArtworkSource  `json:"artworkSource"`
-	Language          string         `json:"language"`
-	TextPreference    TextPreference `json:"textPreference"`
-	Ratings           []string       `json:"ratings"`
-	RatingsLayout     RatingsLayout  `json:"ratingsLayout"`
-	BadgeStyle        BadgeStyle     `json:"badgeStyle"`
-	BadgeTheme        BadgeTheme     `json:"badgeTheme"`
-	Badges            []string       `json:"badges,omitempty"`
-	AgeRating         bool           `json:"ageRating"`
-	AgeRatingPos      string         `json:"ageRatingPos,omitempty"`
-	Genre             bool           `json:"genre"`
-	GenrePos          string         `json:"genrePos,omitempty"`
-	Providers         bool           `json:"providers"`
-	ProvidersCountry  string         `json:"providersCountry,omitempty"`
-	AggregateBar      bool           `json:"aggregateBar"`
-	AggregateBarPos   string         `json:"aggregateBarPos,omitempty"` // "top" | "bottom"
-	Trending          bool           `json:"trending"`
-	BackdropAsPoster  bool           `json:"backdropAsPoster,omitempty"`
-	BackdropLogo      bool           `json:"backdropLogo,omitempty"`
-	RatingRing      bool   `json:"ratingRing,omitempty"`
-	RatingRingPos   string `json:"ratingRingPos,omitempty"`   // "tl" | "tr" | "bl" | "br"
-	RatingRingColor string `json:"ratingRingColor,omitempty"` // "" = auto (green/amber/red), else "#RRGGBB"
+	Size             MediaSize      `json:"size"`
+	ArtworkSource    ArtworkSource  `json:"artworkSource"`
+	Language         string         `json:"language"`
+	TextPreference   TextPreference `json:"textPreference"`
+	Ratings          []string       `json:"ratings"`
+	RatingsLayout    RatingsLayout  `json:"ratingsLayout"`
+	BadgeStyle       BadgeStyle     `json:"badgeStyle"`
+	BadgeTheme       BadgeTheme     `json:"badgeTheme"`
+	Badges           []string       `json:"badges,omitempty"`
+	AgeRating        bool           `json:"ageRating"`
+	AgeRatingPos     string         `json:"ageRatingPos,omitempty"`
+	Genre            bool           `json:"genre"`
+	GenrePos         string         `json:"genrePos,omitempty"`
+	Providers        bool           `json:"providers"`
+	ProvidersCountry string         `json:"providersCountry,omitempty"`
+	AggregateBar     bool           `json:"aggregateBar"`
+	AggregateBarPos  string         `json:"aggregateBarPos,omitempty"` // "top" | "bottom"
+	Trending         bool           `json:"trending"`
+	TrendingStyle    TrendingStyle  `json:"trendingStyle"`
+	BackdropAsPoster bool           `json:"backdropAsPoster,omitempty"`
+	BackdropLogo     bool           `json:"backdropLogo,omitempty"`
+	RatingRing       bool           `json:"ratingRing,omitempty"`
+	RatingRingPos    string         `json:"ratingRingPos,omitempty"`   // "tl" | "tr" | "bl" | "br"
+	RatingRingColor  string         `json:"ratingRingColor,omitempty"` // "" = auto (green/amber/red), else "#RRGGBB"
 }
 
 // Default returns a Config populated with production defaults.
@@ -110,22 +123,23 @@ func Default() Config {
 		BadgeTheme:     ThemeDark,
 		AgeRating:      true,
 		AgeRatingPos:   "inherit",
+		TrendingStyle:  TrendingArrowWord,
 	}
 }
 
 // raw is the loose JSON shape we accept from profile config fields.
 type raw struct {
-	Size           *string  `json:"size"`
-	ArtworkSource  *string  `json:"artworkSource"`
-	Language       *string  `json:"language"`
-	TextPreference *string  `json:"textPreference"`
-	Ratings        []string `json:"ratings"`
-	RatingsLayout  *string  `json:"ratingsLayout"`
-	BadgeStyle     *string  `json:"badgeStyle"`
-	BadgeTheme     *string  `json:"badgeTheme"`
-	Badges         []string `json:"badges"`
-	AgeRating      *bool    `json:"ageRating"`
-	AgeRatingPos   *string  `json:"ageRatingPos"`
+	Size             *string  `json:"size"`
+	ArtworkSource    *string  `json:"artworkSource"`
+	Language         *string  `json:"language"`
+	TextPreference   *string  `json:"textPreference"`
+	Ratings          []string `json:"ratings"`
+	RatingsLayout    *string  `json:"ratingsLayout"`
+	BadgeStyle       *string  `json:"badgeStyle"`
+	BadgeTheme       *string  `json:"badgeTheme"`
+	Badges           []string `json:"badges"`
+	AgeRating        *bool    `json:"ageRating"`
+	AgeRatingPos     *string  `json:"ageRatingPos"`
 	Genre            *bool    `json:"genre"`
 	GenrePos         *string  `json:"genrePos"`
 	Providers        *bool    `json:"providers"`
@@ -133,11 +147,12 @@ type raw struct {
 	AggregateBar     *bool    `json:"aggregateBar"`
 	AggregateBarPos  *string  `json:"aggregateBarPos"`
 	Trending         *bool    `json:"trending"`
+	TrendingStyle    *string  `json:"trendingStyle"`
 	BackdropAsPoster *bool    `json:"backdropAsPoster"`
 	BackdropLogo     *bool    `json:"backdropLogo"`
-	RatingRing      *bool   `json:"ratingRing"`
-	RatingRingPos   *string `json:"ratingRingPos"`
-	RatingRingColor *string `json:"ratingRingColor"`
+	RatingRing       *bool    `json:"ratingRing"`
+	RatingRingPos    *string  `json:"ratingRingPos"`
+	RatingRingColor  *string  `json:"ratingRingColor"`
 }
 
 // Parse deserializes a profile config JSON blob into a normalized Config.
@@ -231,6 +246,11 @@ func Parse(data json.RawMessage) Config {
 	if r.Trending != nil {
 		cfg.Trending = *r.Trending
 	}
+	if r.TrendingStyle != nil {
+		if v := normalizeTrendingStyle(*r.TrendingStyle); v != "" {
+			cfg.TrendingStyle = v
+		}
+	}
 	if r.BackdropAsPoster != nil {
 		cfg.BackdropAsPoster = *r.BackdropAsPoster
 	}
@@ -276,11 +296,12 @@ func CacheKey(cfg Config) string {
 		AggregateBar     bool           `json:"aggregateBar"`
 		AggregateBarPos  string         `json:"aggregateBarPos"`
 		Trending         bool           `json:"trending"`
-		BackdropAsPoster bool   `json:"backdropAsPoster"`
-		BackdropLogo     bool   `json:"backdropLogo"`
-		RatingRing       bool   `json:"ratingRing"`
-		RatingRingPos    string `json:"ratingRingPos"`
-		RatingRingColor  string `json:"ratingRingColor"`
+		TrendingStyle    TrendingStyle  `json:"trendingStyle"`
+		BackdropAsPoster bool           `json:"backdropAsPoster"`
+		BackdropLogo     bool           `json:"backdropLogo"`
+		RatingRing       bool           `json:"ratingRing"`
+		RatingRingPos    string         `json:"ratingRingPos"`
+		RatingRingColor  string         `json:"ratingRingColor"`
 	}
 	ratings := make([]string, len(cfg.Ratings))
 	copy(ratings, cfg.Ratings)
@@ -308,6 +329,7 @@ func CacheKey(cfg Config) string {
 		AggregateBar:     cfg.AggregateBar,
 		AggregateBarPos:  cfg.AggregateBarPos,
 		Trending:         cfg.Trending,
+		TrendingStyle:    cfg.TrendingStyle,
 		BackdropAsPoster: cfg.BackdropAsPoster,
 		BackdropLogo:     cfg.BackdropLogo,
 		RatingRing:       cfg.RatingRing,
@@ -380,6 +402,22 @@ func normalizeTextPreference(v string) TextPreference {
 		return TextAlternative
 	case "random":
 		return TextRandom
+	}
+	return ""
+}
+
+func normalizeTrendingStyle(v string) TrendingStyle {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "arrow-word", "arrowword", "arrow_word":
+		return TrendingArrowWord
+	case "flame-word", "flameword", "flame_word":
+		return TrendingFlameWord
+	case "word", "word-only", "wordonly":
+		return TrendingWord
+	case "arrow", "arrow-only", "arrowonly":
+		return TrendingArrow
+	case "flame", "flame-only", "flameonly":
+		return TrendingFlame
 	}
 	return ""
 }

--- a/web/components/configurator-client.tsx
+++ b/web/components/configurator-client.tsx
@@ -87,6 +87,7 @@ export function ConfiguratorClient() {
       genre: cfg.genre, genrePos: cfg.genrePos, badges: cfg.badges,
       providers: cfg.providers, aggregateBar: cfg.aggregateBar,
       aggregateBarPos: cfg.aggregateBarPos, trending: cfg.trending,
+      trendingStyle: cfg.trendingStyle,
       backdropAsPoster: cfg.backdropAsPoster,
       ratingRing: cfg.ratingRing,
       ratingRingPos: cfg.ratingRingPos, ratingRingColor: cfg.ratingRingColor,

--- a/web/components/configurator-display.tsx
+++ b/web/components/configurator-display.tsx
@@ -4,7 +4,7 @@ import { Check, AlertCircle } from 'lucide-react';
 import type { ConfigState, UpdateConfigFn } from './configurator-types';
 import {
   ARTWORK_OPTIONS, SIZE_OPTIONS, TEXT_PREF_OPTIONS, LANG_OPTIONS,
-  AGE_POS_OPTIONS, GENRE_POS_OPTIONS, QUALITY_BADGE_OPTIONS,
+  AGE_POS_OPTIONS, GENRE_POS_OPTIONS, QUALITY_BADGE_OPTIONS, TREND_STYLE_OPTIONS,
 } from './configurator-types';
 
 // ── Notice ────────────────────────────────────────────────────────────────────
@@ -250,10 +250,23 @@ export function DisplayPanel({ uid, mediaType, config, onUpdate, onToggleBadge, 
 
         <ToggleRow
           label="Trending badge"
-          hint="Show TRENDING label in top-left corner"
+          hint="Show a trending badge in the top-left corner"
           checked={config.trending}
           onChange={() => onUpdate('trending', !config.trending)}
         />
+
+        {config.trending && (
+          <Field label="Trending style" htmlFor={`${uid}-trendstyle`}>
+            <select
+              id={`${uid}-trendstyle`}
+              className="select"
+              value={config.trendingStyle}
+              onChange={e => onUpdate('trendingStyle', e.target.value)}
+            >
+              {TREND_STYLE_OPTIONS.map(o => <option key={o.id} value={o.id}>{o.label}</option>)}
+            </select>
+          </Field>
+        )}
 
         <button className="btn btn-ghost btn-sm" style={{ alignSelf: 'flex-start' }} onClick={onReset}>
           Reset to defaults

--- a/web/components/configurator-types.ts
+++ b/web/components/configurator-types.ts
@@ -52,6 +52,14 @@ export const BADGE_THEME_OPTIONS = [
   { id: 'light', label: 'Light' },
 ] as const;
 
+export const TREND_STYLE_OPTIONS = [
+  { id: 'arrow-word', label: 'Arrow + word' },
+  { id: 'flame-word', label: 'Flame + word' },
+  { id: 'arrow',      label: 'Arrow only'   },
+  { id: 'flame',      label: 'Flame only'   },
+  { id: 'word',       label: 'Word only'    },
+] as const;
+
 export const RATING_OPTIONS: { id: string; label: string; accent: string; icon: string; group?: string }[] = [
   { id: 'imdb',           label: 'IMDb',            accent: '#f5c518', icon: '/rating-logos/imdb.svg' },
   { id: 'tmdb',           label: 'TMDB',            accent: '#01b4e4', icon: '/rating-logos/tmdb.svg' },
@@ -124,6 +132,7 @@ export interface ConfigState {
   aggregateBar: boolean;
   aggregateBarPos: string;
   trending: boolean;
+  trendingStyle: string;
   backdropAsPoster: boolean;
   ratingRing: boolean;
   ratingRingPos: string;
@@ -148,6 +157,7 @@ export const DEFAULT_CONFIG: ConfigState = {
   aggregateBar: false,
   aggregateBarPos: 'bottom',
   trending: false,
+  trendingStyle: 'arrow-word',
   backdropAsPoster: false,
   ratingRing: false,
   ratingRingPos: 'br',


### PR DESCRIPTION
## Summary

Reworks the trending badge. The old "flame" accent was a symmetric teardrop (`fillFlame`) that read as an orange **water drop**, not fire. This swaps it for crisp vector glyphs and makes the badge composition a configurable option (the icon never has to be a flame).

- **New vector primitives** in `internal/compose/badge_draw.go`: an anti-aliased polyline stroker (`strokePolyline`) and a canonical "trending up" arrow (`fillTrendArrow`); plus a sharper two-tone flame (`fillFlameSharp`). Removed the dead `fillFlame` teardrop.
- `drawTrendingBadgeStyled` renders any icon/word composition; the public `drawTrendingBadge` keeps rendering the default.
- **New render-config field** `trendingStyle` in `internal/imageconfig`: `arrow-word` (default) \| `flame-word` \| `word` \| `arrow` \| `flame`. Parsed, normalized, and folded into the cache key so each style caches independently.
- **Configurator**: a "Trending style" `<select>` shown **only when the Trending badge toggle is on** (follows the project's hide-conflicting-options UX rule).

## Styles

| id | render |
|----|--------|
| `arrow-word` *(default)* | rising arrow + TRENDING |
| `flame-word` | flame + TRENDING |
| `word` | TRENDING only |
| `arrow` | rising arrow only |
| `flame` | flame only |

## Test plan

- `go test ./...` — **255 pass**, incl. new `TestTrendingStyles` (asserts every style draws).
- `go build ./...` and `go vet ./...` — clean.
- Web: `npm run type-check` and `npm run lint` — clean (only a pre-existing unrelated `<img>` warning).
- **Live render check**: ran the API server and rendered `tt0468569` with `trending:true` across `arrow-word`, `flame-word`, `arrow`, and `word`. Each produced the correct, distinct glyph end-to-end (config → `Parse` → mapper → render), and the default reads cleanly on a real poster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable style options for the “Trending” badge: arrow+word, flame+word, word-only, arrow-only, and flame-only.
  * Updated the configurator to show a “Trending style” dropdown when the Trending badge is enabled, and to include the selection in preview rendering.

* **Bug Fixes**
  * Improved badge rendering for smoother, more polished arrow/flame glyphs.
  * Fixed layout/spacing so the badge composes correctly when using icon-only or word-only styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->