### PR TITLE
feat(configurator): per-surface artwork settings

### DIFF
--- a/internal/imageconfig/config.go
+++ b/internal/imageconfig/config.go
@@ -157,7 +157,19 @@ type raw struct {
 
 // Surfaces are the distinct render targets a single profile can style
 // independently. They mirror the media-type path segments served by the API.
+// This is the single source of truth for valid surfaces; server routing and
+// validation derive from it rather than re-declaring the literals.
 var Surfaces = []string{"poster", "backdrop", "thumbnail", "logo"}
+
+// IsSurface reports whether name is a recognized render surface.
+func IsSurface(name string) bool {
+	for _, s := range Surfaces {
+		if s == name {
+			return true
+		}
+	}
+	return false
+}
 
 // surfaceEnvelope is the optional per-surface wrapper. When a profile config
 // carries a non-empty "surfaces" object, each render surface is configured

--- a/internal/imageconfig/config.go
+++ b/internal/imageconfig/config.go
@@ -155,7 +155,39 @@ type raw struct {
 	RatingRingColor  *string  `json:"ratingRingColor"`
 }
 
-// Parse deserializes a profile config JSON blob into a normalized Config.
+// Surfaces are the distinct render targets a single profile can style
+// independently. They mirror the media-type path segments served by the API.
+var Surfaces = []string{"poster", "backdrop", "thumbnail", "logo"}
+
+// surfaceEnvelope is the optional per-surface wrapper. When a profile config
+// carries a non-empty "surfaces" object, each render surface is configured
+// independently. A flat config (no "surfaces" key) applies to every surface,
+// preserving every profile saved before per-surface settings existed.
+type surfaceEnvelope struct {
+	Surfaces map[string]json.RawMessage `json:"surfaces"`
+}
+
+// ParseSurface resolves the Config for a single render surface from a profile
+// config blob. The blob may be either the per-surface envelope
+// {"surfaces":{"poster":{…},"backdrop":{…}}} or a legacy flat config that
+// applies uniformly to every surface. A missing or unknown surface within an
+// envelope falls back to Default(); a flat or empty blob is parsed as before.
+func ParseSurface(data json.RawMessage, surface string) Config {
+	if len(data) == 0 {
+		return Default()
+	}
+	var env surfaceEnvelope
+	if err := json.Unmarshal(data, &env); err == nil && len(env.Surfaces) > 0 {
+		if sub, ok := env.Surfaces[surface]; ok {
+			return Parse(sub)
+		}
+		return Default()
+	}
+	// Flat config — applies to every surface (legacy / live-preview shape).
+	return Parse(data)
+}
+
+// Parse deserializes a flat profile config JSON blob into a normalized Config.
 // Missing or invalid fields fall back to Default() values.
 // An empty or nil blob returns Default().
 func Parse(data json.RawMessage) Config {

--- a/internal/imageconfig/config_test.go
+++ b/internal/imageconfig/config_test.go
@@ -186,6 +186,19 @@ func TestParseSurfaceEmptyReturnsDefault(t *testing.T) {
 	}
 }
 
+func TestIsSurface(t *testing.T) {
+	for _, s := range Surfaces {
+		if !IsSurface(s) {
+			t.Errorf("IsSurface(%q) = false, want true", s)
+		}
+	}
+	for _, bad := range []string{"", "movie", "Poster", "banner", "logo "} {
+		if IsSurface(bad) {
+			t.Errorf("IsSurface(%q) = true, want false", bad)
+		}
+	}
+}
+
 func TestCacheKeyStableForSameConfig(t *testing.T) {
 	cfg := Default()
 	k1 := CacheKey(cfg)

--- a/internal/imageconfig/config_test.go
+++ b/internal/imageconfig/config_test.go
@@ -118,6 +118,74 @@ func TestParseDeduplicatesRatings(t *testing.T) {
 	}
 }
 
+func TestParseSurfaceFlatConfigAppliesToEverySurface(t *testing.T) {
+	// A legacy flat config (no "surfaces" key) must resolve identically for
+	// every surface so profiles saved before per-surface settings keep working.
+	raw := json.RawMessage(`{"size":"large","artworkSource":"fanart","language":"ja"}`)
+	for _, surface := range Surfaces {
+		cfg := ParseSurface(raw, surface)
+		if cfg.Size != SizeLarge {
+			t.Errorf("surface %q Size: got %q, want large", surface, cfg.Size)
+		}
+		if cfg.ArtworkSource != ArtworkFanart {
+			t.Errorf("surface %q ArtworkSource: got %q, want fanart", surface, cfg.ArtworkSource)
+		}
+		if cfg.Language != "ja" {
+			t.Errorf("surface %q Language: got %q, want ja", surface, cfg.Language)
+		}
+	}
+}
+
+func TestParseSurfaceResolvesEachSurfaceIndependently(t *testing.T) {
+	raw := json.RawMessage(`{
+		"v": 2,
+		"surfaces": {
+			"poster":   {"size":"4k","artworkSource":"tmdb","ratingsLayout":"bottom"},
+			"backdrop": {"size":"normal","artworkSource":"fanart","ratingsLayout":"none"}
+		}
+	}`)
+
+	poster := ParseSurface(raw, "poster")
+	if poster.Size != Size4K {
+		t.Errorf("poster Size: got %q, want 4k", poster.Size)
+	}
+	if poster.ArtworkSource != ArtworkTMDB {
+		t.Errorf("poster ArtworkSource: got %q, want tmdb", poster.ArtworkSource)
+	}
+	if poster.RatingsLayout != LayoutBottom {
+		t.Errorf("poster RatingsLayout: got %q, want bottom", poster.RatingsLayout)
+	}
+
+	backdrop := ParseSurface(raw, "backdrop")
+	if backdrop.Size != SizeNormal {
+		t.Errorf("backdrop Size: got %q, want normal", backdrop.Size)
+	}
+	if backdrop.ArtworkSource != ArtworkFanart {
+		t.Errorf("backdrop ArtworkSource: got %q, want fanart", backdrop.ArtworkSource)
+	}
+	if backdrop.RatingsLayout != LayoutNone {
+		t.Errorf("backdrop RatingsLayout: got %q, want none", backdrop.RatingsLayout)
+	}
+}
+
+func TestParseSurfaceMissingSurfaceFallsBackToDefault(t *testing.T) {
+	// Envelope present but the requested surface is absent → Default().
+	raw := json.RawMessage(`{"surfaces":{"poster":{"size":"4k"}}}`)
+	got := ParseSurface(raw, "logo")
+	want := Default()
+	if got.Size != want.Size || got.ArtworkSource != want.ArtworkSource {
+		t.Errorf("missing surface should fall back to Default(), got %+v", got)
+	}
+}
+
+func TestParseSurfaceEmptyReturnsDefault(t *testing.T) {
+	got := ParseSurface(nil, "poster")
+	want := Default()
+	if got.Size != want.Size || got.Language != want.Language {
+		t.Errorf("ParseSurface(nil) != Default(): got %+v", got)
+	}
+}
+
 func TestCacheKeyStableForSameConfig(t *testing.T) {
 	cfg := Default()
 	k1 := CacheKey(cfg)

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -88,7 +88,7 @@ func NewHandler(version string, store *profile.Store, settingsStore *settings.St
 		if configParam != "default" {
 			if len(configParam) > 0 && configParam[0] == '{' {
 				// Inline JSON config — used by the live preview without a saved profile.
-				imgCfg = imageconfig.Parse(json.RawMessage(configParam))
+				imgCfg = imageconfig.ParseSurface(json.RawMessage(configParam), mediaType)
 				profileLoaded = true
 			} else if store != nil {
 				// configParam may be a profile ID or a memorable alias.
@@ -96,7 +96,9 @@ func NewHandler(version string, store *profile.Store, settingsStore *settings.St
 				// into media apps that can't send credentials. The profile
 				// password protects editing (PUT/DELETE), not viewing.
 				if p, err := store.Resolve(configParam); err == nil {
-					imgCfg = imageconfig.Parse(p.Config)
+					// A profile config can style each surface independently;
+					// resolve the one for this request's media type.
+					imgCfg = imageconfig.ParseSurface(p.Config, mediaType)
 					profileLoaded = true
 				}
 			}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -155,7 +155,7 @@ func NewHandler(version string, store *profile.Store, settingsStore *settings.St
 		_, _ = w.Write(pngBytes)
 		ms.Record("/"+mediaType, http.StatusOK, latMs(start))
 	}
-	for _, mt := range []string{"poster", "backdrop", "thumbnail", "logo"} {
+	for _, mt := range imageconfig.Surfaces {
 		mux.HandleFunc("/"+mt+"/{id}", renderHandler)
 	}
 

--- a/internal/server/handler_admin.go
+++ b/internal/server/handler_admin.go
@@ -194,6 +194,13 @@ func registerAdminRoutes(
 
 		imgCfg := imageconfig.Default()
 		if body.Config != "" {
+			// Unlike the public render path (which degrades gracefully), this is
+			// an operator tool — surface a malformed config instead of silently
+			// warming Default().
+			if !json.Valid([]byte(body.Config)) {
+				http.Error(w, "invalid config JSON", http.StatusBadRequest)
+				return
+			}
 			imgCfg = imageconfig.ParseSurface(json.RawMessage(body.Config), mediaType)
 		}
 

--- a/internal/server/handler_admin.go
+++ b/internal/server/handler_admin.go
@@ -185,6 +185,12 @@ func registerAdminRoutes(
 		if mediaType == "" {
 			mediaType = "poster"
 		}
+		// ParseSurface resolves config per surface, so an unknown mediaType would
+		// silently warm Default() instead of the requested surface. Reject it.
+		if !imageconfig.IsSurface(mediaType) {
+			http.Error(w, "unsupported mediaType", http.StatusBadRequest)
+			return
+		}
 
 		imgCfg := imageconfig.Default()
 		if body.Config != "" {

--- a/internal/server/handler_admin.go
+++ b/internal/server/handler_admin.go
@@ -188,7 +188,7 @@ func registerAdminRoutes(
 
 		imgCfg := imageconfig.Default()
 		if body.Config != "" {
-			imgCfg = imageconfig.Parse(json.RawMessage(body.Config))
+			imgCfg = imageconfig.ParseSurface(json.RawMessage(body.Config), mediaType)
 		}
 
 		// Kick off warming in the background; respond immediately.

--- a/web/components/configurator-client.tsx
+++ b/web/components/configurator-client.tsx
@@ -6,8 +6,9 @@ import {
 import { Settings2, Star, Film, Rocket, Link2, Maximize2 } from 'lucide-react';
 import { renderUrl, type MediaType, type Template } from '@/lib/api';
 import {
-  MEDIA_TYPES, DEFAULT_CONFIG, PREVIEW_DEBOUNCE_MS,
-  readSession, encodeShare, decodeShare, type ConfigState,
+  MEDIA_TYPES, DEFAULT_CONFIG, DEFAULT_SURFACE_CONFIGS, PREVIEW_DEBOUNCE_MS,
+  readSession, encodeShare, decodeShare, cloneToAllSurfaces, fromStoredConfig,
+  type ConfigState, type SurfaceConfigs,
 } from './configurator-types';
 import { Notice, DisplayPanel } from './configurator-display';
 import { TemplateStrip, RatingsPanel } from './configurator-panels';
@@ -23,8 +24,11 @@ export function ConfiguratorClient() {
   const [mediaType, setMediaType] = useState<MediaType>('poster');
   const [mediaId, setMediaId] = useState('tt0468569');
   const [mediaTitle, setMediaTitle] = useState('The Dark Knight (2008)');
-  const [config, setConfig] = useState<ConfigState>(DEFAULT_CONFIG);
+  const [configs, setConfigs] = useState<SurfaceConfigs>(DEFAULT_SURFACE_CONFIGS);
   const [hydrated, setHydrated] = useState(false);
+  // The surface currently being edited / previewed. Each surface keeps its own
+  // settings; switching the media-type tab switches which one these controls edit.
+  const config = configs[mediaType];
 
   // Restore persisted state after mount: the page is statically prerendered,
   // so reading storage during the first render mismatches the server HTML
@@ -41,13 +45,21 @@ export function ConfiguratorClient() {
       setMediaType(shared.t);
       setMediaId(shared.id);
       setMediaTitle(shared.title);
-      setConfig(shared.cfg);
+      setConfigs(shared.cfgs);
       history.replaceState(null, '', window.location.pathname + window.location.search);
     } else {
       setMediaType(readSession<MediaType>('xrdb-media-type', 'poster'));
       setMediaId(readSession<string>('xrdb-media-id', 'tt0468569'));
       setMediaTitle(readSession<string>('xrdb-media-title', 'The Dark Knight (2008)'));
-      setConfig({ ...DEFAULT_CONFIG, ...readSession<Partial<ConfigState>>('xrdb-config', {}) });
+      // Prefer the per-surface store; fall back to (and migrate) the older
+      // single-config session so a mid-session upgrade keeps the user's look.
+      const storedSurfaces = readSession<Record<string, unknown> | null>('xrdb-configs', null);
+      if (storedSurfaces) {
+        setConfigs(fromStoredConfig({ surfaces: storedSurfaces }));
+      } else {
+        const legacy = readSession<Partial<ConfigState> | null>('xrdb-config', null);
+        setConfigs(legacy ? cloneToAllSurfaces({ ...DEFAULT_CONFIG, ...legacy }) : DEFAULT_SURFACE_CONFIGS);
+      }
     }
     setHydrated(true);
     /* eslint-enable react-hooks/set-state-in-effect */
@@ -65,7 +77,7 @@ export function ConfiguratorClient() {
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const undoConfigRef = useRef<ConfigState | null>(null);
+  const undoConfigsRef = useRef<SurfaceConfigs | null>(null);
   const [undoAvailable, setUndoAvailable] = useState(false);
 
   useEffect(() => {
@@ -74,9 +86,9 @@ export function ConfiguratorClient() {
       sessionStorage.setItem('xrdb-media-type', JSON.stringify(mediaType));
       sessionStorage.setItem('xrdb-media-id',   JSON.stringify(mediaId));
       sessionStorage.setItem('xrdb-media-title', JSON.stringify(mediaTitle));
-      sessionStorage.setItem('xrdb-config',      JSON.stringify(config));
+      sessionStorage.setItem('xrdb-configs',     JSON.stringify(configs));
     } catch { /* unavailable */ }
-  }, [hydrated, mediaType, mediaId, mediaTitle, config]);
+  }, [hydrated, mediaType, mediaId, mediaTitle, configs]);
 
   const buildSrc = useCallback((type: MediaType, id: string, cfg: ConfigState) => {
     return renderUrl(type, id || 'tt0468569', JSON.stringify({
@@ -128,45 +140,57 @@ export function ConfiguratorClient() {
 
   const updateConfig = <K extends keyof ConfigState>(key: K, value: ConfigState[K]) => {
     markManualEdit();
-    setConfig(c => ({ ...c, [key]: value }));
+    setConfigs(cs => ({ ...cs, [mediaType]: { ...cs[mediaType], [key]: value } }));
   };
 
   const toggleRating = (r: string) => {
     markManualEdit();
-    setConfig(c => ({
-      ...c, ratings: c.ratings.includes(r) ? c.ratings.filter(x => x !== r) : [...c.ratings, r],
-    }));
+    setConfigs(cs => {
+      const cur = cs[mediaType];
+      return { ...cs, [mediaType]: {
+        ...cur, ratings: cur.ratings.includes(r) ? cur.ratings.filter(x => x !== r) : [...cur.ratings, r],
+      } };
+    });
   };
 
   const toggleBadge = (b: string) => {
     markManualEdit();
-    setConfig(c => ({
-      ...c, badges: c.badges.includes(b) ? c.badges.filter(x => x !== b) : [...c.badges, b],
-    }));
+    setConfigs(cs => {
+      const cur = cs[mediaType];
+      return { ...cs, [mediaType]: {
+        ...cur, badges: cur.badges.includes(b) ? cur.badges.filter(x => x !== b) : [...cur.badges, b],
+      } };
+    });
   };
 
   const applyTemplate = (t: Template) => {
     const parsed = t.config as Partial<ConfigState>;
-    undoConfigRef.current = config;
-    setConfig(c => ({ ...c, ...parsed }));
+    undoConfigsRef.current = configs;
+    setConfigs(cs => ({ ...cs, [mediaType]: { ...cs[mediaType], ...parsed } }));
     setAppliedTemplate(t.id);
-    flash('info', `Template "${t.name}" applied`);
+    flash('info', `Template "${t.name}" applied to ${mediaType}`);
     setUndoAvailable(true);
   };
 
   const undoTemplate = () => {
-    if (undoConfigRef.current) {
-      setConfig(undoConfigRef.current);
-      undoConfigRef.current = null;
+    if (undoConfigsRef.current) {
+      setConfigs(undoConfigsRef.current);
+      undoConfigsRef.current = null;
     }
     setAppliedTemplate(null);
     setUndoAvailable(false);
     setNotice(null);
   };
 
-  const handleLoadConfig = (loaded: Partial<ConfigState>) => {
+  const handleLoadConfigs = (loaded: SurfaceConfigs) => {
     markManualEdit();
-    setConfig({ ...DEFAULT_CONFIG, ...loaded });
+    setConfigs(loaded);
+  };
+
+  const copyToAllSurfaces = () => {
+    markManualEdit();
+    setConfigs(cs => cloneToAllSurfaces(cs[mediaType]));
+    flash('success', `Applied ${mediaType} settings to every surface`);
   };
 
   const handleMediaSelect = (id: string, title: string) => {
@@ -175,7 +199,7 @@ export function ConfiguratorClient() {
   };
 
   const shareLook = async () => {
-    const fragment = encodeShare({ t: mediaType, id: mediaId, title: mediaTitle, cfg: config });
+    const fragment = encodeShare({ t: mediaType, id: mediaId, title: mediaTitle, cfgs: configs });
     const link = `${window.location.origin}${window.location.pathname}#c=${fragment}`;
     try {
       await navigator.clipboard.writeText(link);
@@ -321,9 +345,23 @@ export function ConfiguratorClient() {
             ))}
           </div>
 
+          {(activeTab === 'display' || activeTab === 'ratings') && (
+            <div
+              className="surface-scope"
+              style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 'var(--sp-2)', flexWrap: 'wrap', marginBottom: 'var(--sp-3)' }}
+            >
+              <span className="hint" style={{ margin: 0 }}>
+                Editing <strong>{MEDIA_TYPES.find(t => t.id === mediaType)?.label ?? mediaType}</strong> settings — each surface is configured separately.
+              </span>
+              <button className="btn btn-ghost btn-sm" onClick={copyToAllSurfaces}>
+                Copy to all surfaces
+              </button>
+            </div>
+          )}
+
           {activeTab === 'display' && (
             <div id={`${uid}-panel-display`} role="tabpanel" aria-labelledby={`${uid}-tab-display`} className="tabpanel-enter">
-              <DisplayPanel uid={uid} mediaType={mediaType} config={config} onUpdate={updateConfig} onToggleBadge={toggleBadge} onReset={() => { markManualEdit(); setConfig(DEFAULT_CONFIG); }} />
+              <DisplayPanel uid={uid} mediaType={mediaType} config={config} onUpdate={updateConfig} onToggleBadge={toggleBadge} onReset={() => { markManualEdit(); setConfigs(cs => ({ ...cs, [mediaType]: { ...DEFAULT_CONFIG } })); }} />
             </div>
           )}
 
@@ -336,12 +374,12 @@ export function ConfiguratorClient() {
           {activeTab === 'profile' && (
             <div id={`${uid}-panel-profile`} role="tabpanel" aria-labelledby={`${uid}-tab-profile`} className="tabpanel-enter">
               <ProfilePanel
-                config={config}
+                configs={configs}
                 mediaType={mediaType}
                 mediaId={mediaId}
                 loaded={loadedProfile}
                 setLoaded={setLoadedProfile}
-                onLoadConfig={handleLoadConfig}
+                onLoadConfigs={handleLoadConfigs}
                 flash={flash}
               />
             </div>

--- a/web/components/configurator-client.tsx
+++ b/web/components/configurator-client.tsx
@@ -48,7 +48,10 @@ export function ConfiguratorClient() {
       setConfigs(shared.cfgs);
       history.replaceState(null, '', window.location.pathname + window.location.search);
     } else {
-      setMediaType(readSession<MediaType>('xrdb-media-type', 'poster'));
+      // Validate the stored media type before it indexes `configs` — a stale or
+      // corrupted session value would otherwise make the active config undefined.
+      const storedType = readSession<string>('xrdb-media-type', 'poster');
+      setMediaType(MEDIA_TYPES.some(t => t.id === storedType) ? (storedType as MediaType) : 'poster');
       setMediaId(readSession<string>('xrdb-media-id', 'tt0468569'));
       setMediaTitle(readSession<string>('xrdb-media-title', 'The Dark Knight (2008)'));
       // Prefer the per-surface store; fall back to (and migrate) the older

--- a/web/components/configurator-types.ts
+++ b/web/components/configurator-types.ts
@@ -166,6 +166,74 @@ export const DEFAULT_CONFIG: ConfigState = {
 
 export type UpdateConfigFn = <K extends keyof ConfigState>(key: K, value: ConfigState[K]) => void;
 
+// ── Per-surface configs ─────────────────────────────────────────────────────────
+// Each surface (poster, backdrop, thumbnail, logo) is styled independently.
+// A single profile carries all four; the backend resolves the right one from
+// the request path.
+
+export type SurfaceConfigs = Record<MediaType, ConfigState>;
+
+export const STORED_CONFIG_VERSION = 2;
+
+export const DEFAULT_SURFACE_CONFIGS: SurfaceConfigs = {
+  poster:    { ...DEFAULT_CONFIG },
+  backdrop:  { ...DEFAULT_CONFIG },
+  thumbnail: { ...DEFAULT_CONFIG },
+  logo:      { ...DEFAULT_CONFIG },
+};
+
+/** Fill any missing/invalid fields of a partial config from the defaults. */
+function coerceConfig(raw: unknown): ConfigState {
+  if (!raw || typeof raw !== 'object') return { ...DEFAULT_CONFIG };
+  return { ...DEFAULT_CONFIG, ...(raw as Partial<ConfigState>) };
+}
+
+/** Seed all four surfaces from one flat config (legacy → per-surface). */
+export function cloneToAllSurfaces(cfg: ConfigState): SurfaceConfigs {
+  return {
+    poster:    { ...cfg },
+    backdrop:  { ...cfg },
+    thumbnail: { ...cfg },
+    logo:      { ...cfg },
+  };
+}
+
+/**
+ * Build the stored profile config — the per-surface envelope. Saved profiles use
+ * `{ v, surfaces: { poster, backdrop, thumbnail, logo } }` so every surface
+ * renders with its own settings under a single profile key.
+ */
+export function toStoredConfig(configs: SurfaceConfigs): Record<string, unknown> {
+  return {
+    v: STORED_CONFIG_VERSION,
+    surfaces: {
+      poster:    configs.poster,
+      backdrop:  configs.backdrop,
+      thumbnail: configs.thumbnail,
+      logo:      configs.logo,
+    },
+  };
+}
+
+/**
+ * Parse a stored profile config back into per-surface state. Accepts both the
+ * per-surface envelope and a legacy flat config (applied to every surface), so
+ * profiles and share links saved before per-surface settings keep working.
+ */
+export function fromStoredConfig(raw: unknown): SurfaceConfigs {
+  if (raw && typeof raw === 'object' && 'surfaces' in raw) {
+    const surfaces = ((raw as { surfaces?: Record<string, unknown> }).surfaces) ?? {};
+    return {
+      poster:    coerceConfig(surfaces.poster),
+      backdrop:  coerceConfig(surfaces.backdrop),
+      thumbnail: coerceConfig(surfaces.thumbnail),
+      logo:      coerceConfig(surfaces.logo),
+    };
+  }
+  // Legacy flat config — apply uniformly to every surface.
+  return cloneToAllSurfaces(coerceConfig(raw));
+}
+
 // ── Utilities ─────────────────────────────────────────────────────────────────
 
 export function readSession<T>(key: string, fallback: T): T {
@@ -184,7 +252,7 @@ export interface ShareState {
   t: MediaType;
   id: string;
   title: string;
-  cfg: ConfigState;
+  cfgs: SurfaceConfigs;
 }
 
 export function encodeShare(state: ShareState): string {
@@ -199,8 +267,17 @@ export function decodeShare(fragment: string): ShareState | null {
   try {
     const b64 = fragment.replace(/-/g, '+').replace(/_/g, '/');
     const bytes = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
-    const parsed = JSON.parse(new TextDecoder().decode(bytes)) as Partial<ShareState>;
-    if (!parsed || typeof parsed.id !== 'string' || typeof parsed.cfg !== 'object' || parsed.cfg === null) return null;
+    const parsed = JSON.parse(new TextDecoder().decode(bytes)) as
+      Partial<ShareState> & { cfg?: unknown; cfgs?: unknown };
+    if (!parsed || typeof parsed.id !== 'string') return null;
+    // Accept the per-surface shape (cfgs) and the legacy single-config shape
+    // (cfg, applied to every surface) so older links still resolve.
+    const hasCfgs = !!parsed.cfgs && typeof parsed.cfgs === 'object';
+    const hasCfg = !!parsed.cfg && typeof parsed.cfg === 'object';
+    if (!hasCfgs && !hasCfg) return null;
+    const cfgs = hasCfgs
+      ? fromStoredConfig({ surfaces: parsed.cfgs })
+      : cloneToAllSurfaces({ ...DEFAULT_CONFIG, ...(parsed.cfg as Partial<ConfigState>) });
     const t = typeof parsed.t === 'string' && MEDIA_TYPES.some(m => m.id === parsed.t)
       ? (parsed.t as MediaType)
       : 'poster';
@@ -208,7 +285,7 @@ export function decodeShare(fragment: string): ShareState | null {
       t,
       id: parsed.id,
       title: typeof parsed.title === 'string' ? parsed.title : parsed.id,
-      cfg: { ...DEFAULT_CONFIG, ...parsed.cfg },
+      cfgs,
     };
   } catch {
     return null;

--- a/web/components/configurator-types.ts
+++ b/web/components/configurator-types.ts
@@ -182,10 +182,27 @@ export const DEFAULT_SURFACE_CONFIGS: SurfaceConfigs = {
   logo:      { ...DEFAULT_CONFIG },
 };
 
-/** Fill any missing/invalid fields of a partial config from the defaults. */
+/** Coerce only the string entries of an array-typed field; fall back to default. */
+function coerceStringArray(value: unknown, fallback: string[]): string[] {
+  if (!Array.isArray(value)) return [...fallback];
+  return value.filter((v): v is string => typeof v === 'string');
+}
+
+/**
+ * Fill any missing/invalid fields of a partial config from the defaults. Array
+ * fields are validated explicitly — malformed stored/shared data (e.g.
+ * `ratings: "imdb"` or `badges: {}`) would otherwise crash the controls that
+ * call array methods on them.
+ */
 function coerceConfig(raw: unknown): ConfigState {
   if (!raw || typeof raw !== 'object') return { ...DEFAULT_CONFIG };
-  return { ...DEFAULT_CONFIG, ...(raw as Partial<ConfigState>) };
+  const input = raw as Partial<Record<keyof ConfigState, unknown>>;
+  return {
+    ...DEFAULT_CONFIG,
+    ...(raw as Partial<ConfigState>),
+    ratings: coerceStringArray(input.ratings, DEFAULT_CONFIG.ratings),
+    badges: coerceStringArray(input.badges, DEFAULT_CONFIG.badges),
+  };
 }
 
 /** Seed all four surfaces from one flat config (legacy → per-surface). */
@@ -277,7 +294,7 @@ export function decodeShare(fragment: string): ShareState | null {
     if (!hasCfgs && !hasCfg) return null;
     const cfgs = hasCfgs
       ? fromStoredConfig({ surfaces: parsed.cfgs })
-      : cloneToAllSurfaces({ ...DEFAULT_CONFIG, ...(parsed.cfg as Partial<ConfigState>) });
+      : cloneToAllSurfaces(coerceConfig(parsed.cfg));
     const t = typeof parsed.t === 'string' && MEDIA_TYPES.some(m => m.id === parsed.t)
       ? (parsed.t as MediaType)
       : 'poster';

--- a/web/components/profile-panel.tsx
+++ b/web/components/profile-panel.tsx
@@ -6,7 +6,7 @@ import {
   createProfile, getProfile, updateProfile, deleteProfile, exportProfile,
   renderOrigin, type MediaType,
 } from '@/lib/api';
-import type { ConfigState } from './configurator-types';
+import { toStoredConfig, fromStoredConfig, type SurfaceConfigs } from './configurator-types';
 import { CopyButton } from './copy-button';
 
 const ALIAS_RE = /^[a-z]{3,32}$/;
@@ -56,17 +56,17 @@ export interface LoadedProfile {
 }
 
 interface ProfilePanelProps {
-  config: ConfigState;
+  configs: SurfaceConfigs;
   mediaType: MediaType;
   mediaId: string;
   loaded: LoadedProfile | null;
   setLoaded: (p: LoadedProfile | null) => void;
-  onLoadConfig: (config: Partial<ConfigState>) => void;
+  onLoadConfigs: (configs: SurfaceConfigs) => void;
   flash: (type: 'error' | 'success' | 'info', message: string) => void;
 }
 
 export function ProfilePanel({
-  config, mediaType, mediaId, loaded, setLoaded, onLoadConfig, flash,
+  configs, mediaType, mediaId, loaded, setLoaded, onLoadConfigs, flash,
 }: ProfilePanelProps) {
   const uid = useId();
   const [name, setName] = useState('');
@@ -108,7 +108,7 @@ export function ProfilePanel({
         name: name.trim(),
         alias: trimmedAlias || undefined,
         type: mediaType,
-        config: config as unknown as Record<string, unknown>,
+        config: toStoredConfig(configs),
         password: password || undefined,
       });
       setLoaded({
@@ -137,7 +137,7 @@ export function ProfilePanel({
     setBusy(true);
     try {
       const p = await getProfile(key, loadPassword || undefined);
-      onLoadConfig(p.config as Partial<ConfigState>);
+      onLoadConfigs(fromStoredConfig(p.config));
       setLoaded({
         id: p.id,
         alias: p.alias ?? '',
@@ -167,7 +167,7 @@ export function ProfilePanel({
         {
           name: loaded.name,
           type: mediaType,
-          config: config as unknown as Record<string, unknown>,
+          config: toStoredConfig(configs),
         },
         loaded.password || undefined,
       );


### PR DESCRIPTION
## Summary

Artwork settings are now configured **per surface** (poster, backdrop, thumbnail, logo) instead of every surface sharing one config. Edit each surface independently, save them all under a single profile, and each surface URL renders with its own settings.

### How it works
- **Storage:** a profile config becomes `{ "v": 2, "surfaces": { poster, backdrop, thumbnail, logo } }`.
- **Backward compatible:** a legacy flat config (no `surfaces` key) parses and applies to every surface, so existing profiles, share links, and saved sessions render identically until edited and re-saved.
- **One key, four surfaces:** install URLs already carry the surface in the path (`/poster/{id}?config=KEY`, `/backdrop/...`), so the backend resolves the right surface per request — no install-flow changes.

### Backend (Go)
- New `imageconfig.ParseSurface(blob, surface)`; the render and cache-warm handlers resolve the surface from the request path. `Parse` keeps its original behavior; cache keys already include the surface.

### Web
- Media-type tabs now select which surface the controls edit; added an "Editing &lt;Surface&gt; settings" banner and a "Copy to all surfaces" helper. Save/load, share links, and session storage carry the per-surface model with automatic migration from the old single-config shape.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./...` — incl. new `ParseSurface` tests (flat→all-surfaces, per-surface independence, missing-surface fallback, empty→default)
- [x] `golangci-lint run` → 0 issues
- [x] web `npm run lint`, `npm run type-check`, `npm run build`
- [ ] Manual: edit poster vs backdrop independently, save profile, confirm each surface URL renders its own settings; load a pre-existing (flat) profile and confirm unchanged rendering


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-surface configuration so posters, backdrops, thumbnails and logos can have independent settings.
  * Updated sharing and profile saving/loading to keep surface-specific configurations.
  * Added “Copy to all surfaces” to replicate the current surface’s settings across all others.
* **Bug Fixes**
  * Media rendering now consistently applies the correct surface configuration for the selected media type.
  * Improved fallbacks for missing/empty/invalid surface data by returning defaults.
  * Admin warm requests now validate the requested media type and apply the matching surface configuration before warming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->