### PR TITLE
fix(cache): bound the render cache and stop stats directory scans

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -108,10 +108,11 @@ func main() {
 		pipeline = compose.New(reg)
 	}
 
-	renderCache, err := cache.New(cfg.CacheDir, cfg.CacheTTL, 300)
+	renderCache, err := cache.New(cfg.CacheDir, cfg.CacheTTL, 300, 256<<20)
 	if err != nil {
 		log.Fatalf("open render cache: %v", err)
 	}
+	defer renderCache.Close()
 
 	handler := server.NewHandler(cfg.Version, store, settingsStore, pipeline, renderCache, cfg, ui.FS())
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -108,7 +108,7 @@ func main() {
 		pipeline = compose.New(reg)
 	}
 
-	renderCache, err := cache.New(cfg.CacheDir, cfg.CacheTTL, 300, 256<<20)
+	renderCache, err := cache.New(cfg.CacheDir, cfg.CacheTTL, cfg.CacheMaxEntries, cfg.CacheMaxBytes)
 	if err != nil {
 		log.Fatalf("open render cache: %v", err)
 	}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -2,12 +2,16 @@
 package cache
 
 import (
+	"container/list"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -17,29 +21,72 @@ type Entry struct {
 	ExpiresAt time.Time
 }
 
+// Disk tier bounds, enforced by the background sweep. Without the sweep the
+// directory only shrinks when an expired key happens to be read again, so a
+// long-lived instance accumulates files without limit.
+const (
+	sweepInterval    = 10 * time.Minute
+	maxDiskFiles     = 20_000
+	maxDiskBytes     = 2 << 30 // 2 GiB
+	expiryHeaderSize = 8
+)
+
+type hotEntry struct {
+	key   string
+	entry *Entry
+}
+
 // Cache is a thread-safe two-tier render cache.
-// Hot entries live in memory (bounded by maxEntries); all entries persist to disk.
+// Hot entries live in memory, bounded by entry count and total bytes; all
+// entries persist to disk, bounded by the background sweep.
 type Cache struct {
-	mu         sync.Mutex
 	dir        string
 	ttl        time.Duration
 	maxEntries int
-	hot        map[string]*Entry // in-memory tier
-	order      []string          // insertion order for LRU eviction
+	maxBytes   int64
+
+	mu       sync.Mutex
+	hot      map[string]*list.Element // value: *hotEntry
+	lru      *list.List               // front = least recently used
+	hotBytes int64
+
+	// Maintained incrementally on Set/expiry and reconciled by each sweep,
+	// so Stats never has to enumerate the cache directory.
+	diskFiles atomic.Int64
+	diskBytes atomic.Int64
+
+	stop chan struct{}
+	done chan struct{}
 }
 
-// New creates a Cache backed by dir with the given TTL and memory cap.
-func New(dir string, ttl time.Duration, maxEntries int) (*Cache, error) {
+// New creates a Cache backed by dir, bounded in memory by maxEntries and
+// maxBytes, and starts the background disk sweep. Call Close to stop it.
+func New(dir string, ttl time.Duration, maxEntries int, maxBytes int64) (*Cache, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("cache mkdir: %w", err)
 	}
-	return &Cache{
+	c := &Cache{
 		dir:        dir,
 		ttl:        ttl,
 		maxEntries: maxEntries,
-		hot:        make(map[string]*Entry, maxEntries),
-		order:      make([]string, 0, maxEntries),
-	}, nil
+		maxBytes:   maxBytes,
+		hot:        make(map[string]*list.Element, maxEntries),
+		lru:        list.New(),
+		stop:       make(chan struct{}),
+		done:       make(chan struct{}),
+	}
+	go c.sweepLoop()
+	return c, nil
+}
+
+// Close stops the background disk sweep and waits for it to exit.
+func (c *Cache) Close() {
+	select {
+	case <-c.stop:
+	default:
+		close(c.stop)
+	}
+	<-c.done
 }
 
 // Get returns a cached entry for key, or (nil, false) on miss or expiry.
@@ -47,13 +94,14 @@ func (c *Cache) Get(key string) (*Entry, bool) {
 	c.mu.Lock()
 
 	// Hot tier — check without holding for I/O.
-	if e, ok := c.hot[key]; ok {
-		if time.Now().Before(e.ExpiresAt) {
-			c.touch(key)
+	if el, ok := c.hot[key]; ok {
+		he := el.Value.(*hotEntry)
+		if time.Now().Before(he.entry.ExpiresAt) {
+			c.lru.MoveToBack(el)
 			c.mu.Unlock()
-			return e, true
+			return he.entry, true
 		}
-		c.evict(key)
+		c.removeLocked(el)
 	}
 	diskPath := c.diskPath(key)
 	c.mu.Unlock()
@@ -63,25 +111,32 @@ func (c *Cache) Get(key string) (*Entry, bool) {
 	if err != nil {
 		return nil, false
 	}
-	if len(data) < 8 {
+	if len(data) < expiryHeaderSize {
 		return nil, false
 	}
-	// First 8 bytes: Unix nanosecond expiry (big-endian int64)
-	exp := int64(data[0])<<56 | int64(data[1])<<48 | int64(data[2])<<40 | int64(data[3])<<32 |
-		int64(data[4])<<24 | int64(data[5])<<16 | int64(data[6])<<8 | int64(data[7])
+	exp := decodeExpiry(data[:expiryHeaderSize])
 	if time.Now().UnixNano() > exp {
-		_ = os.Remove(diskPath)
+		if info, statErr := os.Stat(diskPath); statErr == nil {
+			if os.Remove(diskPath) == nil {
+				c.diskFiles.Add(-1)
+				c.diskBytes.Add(-info.Size())
+			}
+		}
 		return nil, false
 	}
-	e := &Entry{Data: data[8:], ExpiresAt: time.Unix(0, exp)}
+	e := &Entry{Data: data[expiryHeaderSize:], ExpiresAt: time.Unix(0, exp)}
 	c.mu.Lock()
 	// Re-check hot tier: another goroutine may have promoted this entry while we were reading disk.
-	if existing, ok := c.hot[key]; ok && time.Now().Before(existing.ExpiresAt) {
-		c.touch(key)
-		c.mu.Unlock()
-		return existing, true
+	if el, ok := c.hot[key]; ok {
+		he := el.Value.(*hotEntry)
+		if time.Now().Before(he.entry.ExpiresAt) {
+			c.lru.MoveToBack(el)
+			c.mu.Unlock()
+			return he.entry, true
+		}
+		c.removeLocked(el)
 	}
-	c.store(key, e)
+	c.storeLocked(key, e)
 	c.mu.Unlock()
 	return e, true
 }
@@ -101,42 +156,53 @@ func (c *Cache) SetWithTTL(key string, data []byte, ttl time.Duration) error {
 	e := &Entry{Data: data, ExpiresAt: exp}
 
 	c.mu.Lock()
-	c.store(key, e)
+	if el, ok := c.hot[key]; ok {
+		c.removeLocked(el)
+	}
+	c.storeLocked(key, e)
 	diskPath := c.diskPath(key)
 	c.mu.Unlock()
 
 	// Persist to disk — no lock held during filesystem I/O.
 	expNs := exp.UnixNano()
-	hdr := [8]byte{
+	hdr := [expiryHeaderSize]byte{
 		byte(expNs >> 56), byte(expNs >> 48), byte(expNs >> 40), byte(expNs >> 32),
 		byte(expNs >> 24), byte(expNs >> 16), byte(expNs >> 8), byte(expNs),
 	}
-	payload := make([]byte, 8+len(data))
-	copy(payload[:8], hdr[:])
-	copy(payload[8:], data)
+	payload := make([]byte, expiryHeaderSize+len(data))
+	copy(payload[:expiryHeaderSize], hdr[:])
+	copy(payload[expiryHeaderSize:], data)
 
+	var prevSize int64 = -1
+	if info, err := os.Stat(diskPath); err == nil {
+		prevSize = info.Size()
+	}
 	if err := os.WriteFile(diskPath, payload, 0o644); err != nil {
 		return fmt.Errorf("cache write: %w", err)
+	}
+	if prevSize >= 0 {
+		c.diskBytes.Add(int64(len(payload)) - prevSize)
+	} else {
+		c.diskFiles.Add(1)
+		c.diskBytes.Add(int64(len(payload)))
 	}
 	return nil
 }
 
-// Stats returns a snapshot of cache state.
+// Stats returns a snapshot of cache state without touching the filesystem.
 func (c *Cache) Stats() Stats {
 	c.mu.Lock()
 	hotCount := len(c.hot)
+	hotBytes := c.hotBytes
 	dir := c.dir
 	ttl := c.ttl
 	c.mu.Unlock()
 
-	entries, err := filepath.Glob(filepath.Join(dir, "*.bin"))
-	diskEntries := len(entries)
-	if err != nil {
-		diskEntries = -1
-	}
 	return Stats{
 		HotEntries:  hotCount,
-		DiskEntries: diskEntries,
+		HotBytes:    hotBytes,
+		DiskEntries: int(c.diskFiles.Load()),
+		DiskBytes:   c.diskBytes.Load(),
 		Dir:         dir,
 		TTL:         ttl.String(),
 	}
@@ -145,48 +211,126 @@ func (c *Cache) Stats() Stats {
 // Stats is a point-in-time view of cache state.
 type Stats struct {
 	HotEntries  int    `json:"hotEntries"`
+	HotBytes    int64  `json:"hotBytes"`
 	DiskEntries int    `json:"diskEntries"`
+	DiskBytes   int64  `json:"diskBytes"`
 	Dir         string `json:"dir"`
 	TTL         string `json:"ttl"`
 }
 
-func (c *Cache) store(key string, e *Entry) {
-	if _, exists := c.hot[key]; !exists {
-		if len(c.hot) >= c.maxEntries {
-			// Evict least-recently used (front of order slice).
-			if len(c.order) > 0 {
-				oldest := c.order[0]
-				c.order = c.order[1:]
-				delete(c.hot, oldest)
-			}
-		}
-		c.order = append(c.order, key)
-	} else {
-		c.touch(key)
-	}
-	c.hot[key] = e
-}
-
-// touch moves key to the most-recently-used position (end of order).
-// Must be called with c.mu held.
-func (c *Cache) touch(key string) {
-	for i, k := range c.order {
-		if k == key {
-			c.order = append(c.order[:i], c.order[i+1:]...)
-			c.order = append(c.order, key)
-			return
-		}
-	}
-}
-
-func (c *Cache) evict(key string) {
-	delete(c.hot, key)
-	for i, k := range c.order {
-		if k == key {
-			c.order = append(c.order[:i], c.order[i+1:]...)
+// storeLocked inserts key at the most-recently-used position and evicts from
+// the least-recently-used end until both memory caps hold.
+// Must be called with c.mu held and key absent from c.hot.
+func (c *Cache) storeLocked(key string, e *Entry) {
+	el := c.lru.PushBack(&hotEntry{key: key, entry: e})
+	c.hot[key] = el
+	c.hotBytes += int64(len(e.Data))
+	for (len(c.hot) > c.maxEntries || c.hotBytes > c.maxBytes) && c.lru.Len() > 1 {
+		front := c.lru.Front()
+		if front == nil || front == el {
 			break
 		}
+		c.removeLocked(front)
 	}
+}
+
+// removeLocked drops an element from both LRU structures and the byte count.
+// Must be called with c.mu held.
+func (c *Cache) removeLocked(el *list.Element) {
+	he := el.Value.(*hotEntry)
+	c.lru.Remove(el)
+	delete(c.hot, he.key)
+	c.hotBytes -= int64(len(he.entry.Data))
+}
+
+func (c *Cache) sweepLoop() {
+	defer close(c.done)
+	c.sweep()
+	ticker := time.NewTicker(sweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-ticker.C:
+			c.sweep()
+		}
+	}
+}
+
+// sweep removes expired disk entries, enforces the disk bounds oldest-first,
+// and reconciles the counters that back Stats.
+func (c *Cache) sweep() {
+	c.sweepWithBounds(maxDiskFiles, maxDiskBytes)
+}
+
+func (c *Cache) sweepWithBounds(fileBound int, byteBound int64) {
+	dirEntries, err := os.ReadDir(c.dir)
+	if err != nil {
+		return
+	}
+
+	type diskFile struct {
+		path  string
+		size  int64
+		mtime time.Time
+	}
+	files := make([]diskFile, 0, len(dirEntries))
+	now := time.Now().UnixNano()
+	for _, de := range dirEntries {
+		if de.IsDir() || filepath.Ext(de.Name()) != ".bin" {
+			continue
+		}
+		path := filepath.Join(c.dir, de.Name())
+		info, err := de.Info()
+		if err != nil {
+			continue
+		}
+		if exp, ok := readExpiry(path); ok && now > exp {
+			_ = os.Remove(path)
+			continue
+		}
+		files = append(files, diskFile{path: path, size: info.Size(), mtime: info.ModTime()})
+	}
+
+	sort.Slice(files, func(i, j int) bool { return files[i].mtime.Before(files[j].mtime) })
+	var totalBytes int64
+	for _, f := range files {
+		totalBytes += f.size
+	}
+	remaining := len(files)
+	for _, f := range files {
+		if remaining <= fileBound && totalBytes <= byteBound {
+			break
+		}
+		if os.Remove(f.path) == nil {
+			remaining--
+			totalBytes -= f.size
+		}
+	}
+
+	c.diskFiles.Store(int64(remaining))
+	c.diskBytes.Store(totalBytes)
+}
+
+// readExpiry reads the expiry header without loading the payload.
+func readExpiry(path string) (int64, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, false
+	}
+	defer f.Close()
+	var hdr [expiryHeaderSize]byte
+	if _, err := io.ReadFull(f, hdr[:]); err != nil {
+		return 0, false
+	}
+	return decodeExpiry(hdr[:]), true
+}
+
+// decodeExpiry parses the big-endian Unix nanosecond expiry header.
+func decodeExpiry(hdr []byte) int64 {
+	return int64(hdr[0])<<56 | int64(hdr[1])<<48 | int64(hdr[2])<<40 | int64(hdr[3])<<32 |
+		int64(hdr[4])<<24 | int64(hdr[5])<<16 | int64(hdr[6])<<8 | int64(hdr[7])
 }
 
 func (c *Cache) diskPath(key string) string {

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -4,6 +4,7 @@ package cache
 import (
 	"container/list"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -55,8 +56,9 @@ type Cache struct {
 	diskFiles atomic.Int64
 	diskBytes atomic.Int64
 
-	stop chan struct{}
-	done chan struct{}
+	stop     chan struct{}
+	stopOnce sync.Once
+	done     chan struct{}
 }
 
 // New creates a Cache backed by dir, bounded in memory by maxEntries and
@@ -80,12 +82,9 @@ func New(dir string, ttl time.Duration, maxEntries int, maxBytes int64) (*Cache,
 }
 
 // Close stops the background disk sweep and waits for it to exit.
+// Safe to call multiple times and from concurrent goroutines.
 func (c *Cache) Close() {
-	select {
-	case <-c.stop:
-	default:
-		close(c.stop)
-	}
+	c.stopOnce.Do(func() { close(c.stop) })
 	<-c.done
 }
 
@@ -164,13 +163,8 @@ func (c *Cache) SetWithTTL(key string, data []byte, ttl time.Duration) error {
 	c.mu.Unlock()
 
 	// Persist to disk — no lock held during filesystem I/O.
-	expNs := exp.UnixNano()
-	hdr := [expiryHeaderSize]byte{
-		byte(expNs >> 56), byte(expNs >> 48), byte(expNs >> 40), byte(expNs >> 32),
-		byte(expNs >> 24), byte(expNs >> 16), byte(expNs >> 8), byte(expNs),
-	}
 	payload := make([]byte, expiryHeaderSize+len(data))
-	copy(payload[:expiryHeaderSize], hdr[:])
+	binary.BigEndian.PutUint64(payload[:expiryHeaderSize], uint64(exp.UnixNano()))
 	copy(payload[expiryHeaderSize:], data)
 
 	var prevSize int64 = -1
@@ -329,8 +323,7 @@ func readExpiry(path string) (int64, bool) {
 
 // decodeExpiry parses the big-endian Unix nanosecond expiry header.
 func decodeExpiry(hdr []byte) int64 {
-	return int64(hdr[0])<<56 | int64(hdr[1])<<48 | int64(hdr[2])<<40 | int64(hdr[3])<<32 |
-		int64(hdr[4])<<24 | int64(hdr[5])<<16 | int64(hdr[6])<<8 | int64(hdr[7])
+	return int64(binary.BigEndian.Uint64(hdr))
 }
 
 func (c *Cache) diskPath(key string) string {

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -2,16 +2,18 @@ package cache
 
 import (
 	"bytes"
+	"path/filepath"
 	"testing"
 	"time"
 )
 
 func openTestCache(t *testing.T) *Cache {
 	t.Helper()
-	c, err := New(t.TempDir(), time.Minute, 10)
+	c, err := New(t.TempDir(), time.Minute, 10, 1<<20)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
+	t.Cleanup(c.Close)
 	return c
 }
 
@@ -38,7 +40,8 @@ func TestMissReturnsNotFound(t *testing.T) {
 }
 
 func TestExpiredEntryIsAMiss(t *testing.T) {
-	c, _ := New(t.TempDir(), time.Millisecond, 10)
+	c, _ := New(t.TempDir(), time.Millisecond, 10, 1<<20)
+	t.Cleanup(c.Close)
 	_ = c.Set("k1", []byte("data"))
 	time.Sleep(5 * time.Millisecond)
 	if _, ok := c.Get("k1"); ok {
@@ -48,11 +51,13 @@ func TestExpiredEntryIsAMiss(t *testing.T) {
 
 func TestDiskPersistence(t *testing.T) {
 	dir := t.TempDir()
-	c1, _ := New(dir, time.Hour, 10)
+	c1, _ := New(dir, time.Hour, 10, 1<<20)
+	t.Cleanup(c1.Close)
 	_ = c1.Set("persistent", []byte("important data"))
 
 	// Re-open with empty hot tier
-	c2, _ := New(dir, time.Hour, 10)
+	c2, _ := New(dir, time.Hour, 10, 1<<20)
+	t.Cleanup(c2.Close)
 	e, ok := c2.Get("persistent")
 	if !ok {
 		t.Fatal("expected disk cache hit in new instance")
@@ -63,7 +68,8 @@ func TestDiskPersistence(t *testing.T) {
 }
 
 func TestLRUEviction(t *testing.T) {
-	c, _ := New(t.TempDir(), time.Minute, 3)
+	c, _ := New(t.TempDir(), time.Minute, 3, 1<<20)
+	t.Cleanup(c.Close)
 	_ = c.Set("a", []byte("a"))
 	_ = c.Set("b", []byte("b"))
 	_ = c.Set("c", []byte("c"))
@@ -71,12 +77,75 @@ func TestLRUEviction(t *testing.T) {
 
 	c.mu.Lock()
 	_, aInHot := c.hot["a"]
+	hotLen := len(c.hot)
 	c.mu.Unlock()
 	if aInHot {
 		t.Error("expected 'a' to be evicted from hot tier")
 	}
-	if len(c.hot) > 3 {
-		t.Errorf("hot tier exceeded max: %d", len(c.hot))
+	if hotLen > 3 {
+		t.Errorf("hot tier exceeded max: %d", hotLen)
+	}
+}
+
+func TestByteCapEviction(t *testing.T) {
+	c, err := New(t.TempDir(), time.Minute, 100, 30)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(c.Close)
+	_ = c.Set("a", bytes.Repeat([]byte("a"), 20))
+	_ = c.Set("b", bytes.Repeat([]byte("b"), 20)) // 40 bytes total exceeds the 30 byte cap
+
+	c.mu.Lock()
+	_, aInHot := c.hot["a"]
+	_, bInHot := c.hot["b"]
+	hotBytes := c.hotBytes
+	c.mu.Unlock()
+	if aInHot {
+		t.Error("expected 'a' to be evicted by the byte cap")
+	}
+	if !bInHot {
+		t.Error("expected 'b' to stay resident")
+	}
+	if hotBytes > 30 {
+		t.Errorf("hot bytes above cap: %d", hotBytes)
+	}
+}
+
+func TestSweepRemovesExpiredDiskEntries(t *testing.T) {
+	dir := t.TempDir()
+	c, _ := New(dir, 5*time.Millisecond, 10, 1<<20)
+	t.Cleanup(c.Close)
+	_ = c.Set("gone", []byte("payload"))
+	time.Sleep(10 * time.Millisecond)
+
+	c.sweep()
+
+	remaining, _ := filepath.Glob(filepath.Join(dir, "*.bin"))
+	if len(remaining) != 0 {
+		t.Errorf("expected expired file removed, found %d", len(remaining))
+	}
+	if got := c.Stats().DiskEntries; got != 0 {
+		t.Errorf("expected 0 disk entries after sweep, got %d", got)
+	}
+}
+
+func TestSweepEnforcesDiskFileBound(t *testing.T) {
+	dir := t.TempDir()
+	c, _ := New(dir, time.Hour, 10, 1<<20)
+	t.Cleanup(c.Close)
+	for _, key := range []string{"a", "b", "c", "d", "e"} {
+		_ = c.Set(key, []byte("data-"+key))
+	}
+
+	c.sweepWithBounds(3, 1<<20)
+
+	remaining, _ := filepath.Glob(filepath.Join(dir, "*.bin"))
+	if len(remaining) != 3 {
+		t.Errorf("expected 3 files after bounded sweep, found %d", len(remaining))
+	}
+	if got := c.Stats().DiskEntries; got != 3 {
+		t.Errorf("expected 3 disk entries reported, got %d", got)
 	}
 }
 
@@ -89,5 +158,8 @@ func TestStats(t *testing.T) {
 	}
 	if s.DiskEntries != 1 {
 		t.Errorf("expected 1 disk entry, got %d", s.DiskEntries)
+	}
+	if s.HotBytes != int64(len("data")) {
+		t.Errorf("expected hot bytes %d, got %d", len("data"), s.HotBytes)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,8 @@ type Config struct {
 	DBPath              string
 	CacheDir            string
 	CacheTTL            time.Duration
+	CacheMaxEntries     int   // hot tier entry cap
+	CacheMaxBytes       int64 // hot tier byte cap
 	TMDBAPIKey          string
 	TMDBReadToken       string
 	MDBListAPIKey       string
@@ -79,6 +81,18 @@ func Load() Config {
 			cacheTTL = d
 		}
 	}
+	cacheMaxEntries := 300
+	if raw := os.Getenv("XRDB_CACHE_MAX_ENTRIES"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			cacheMaxEntries = n
+		}
+	}
+	var cacheMaxBytes int64 = 256 << 20
+	if raw := os.Getenv("XRDB_CACHE_MAX_MB"); raw != "" {
+		if n, err := strconv.ParseInt(raw, 10, 64); err == nil && n > 0 {
+			cacheMaxBytes = n << 20
+		}
+	}
 	var animeMapRefresh time.Duration
 	if raw := os.Getenv("XRDB_ANIME_MAP_REFRESH_HOURS"); raw != "" {
 		if h, err := strconv.ParseFloat(raw, 64); err == nil && h > 0 {
@@ -91,6 +105,8 @@ func Load() Config {
 		DBPath:                dbPath,
 		CacheDir:              cacheDir,
 		CacheTTL:              cacheTTL,
+		CacheMaxEntries:       cacheMaxEntries,
+		CacheMaxBytes:         cacheMaxBytes,
 		TMDBAPIKey:            os.Getenv("XRDB_TMDB_API_KEY"),
 		TMDBReadToken:         os.Getenv("XRDB_TMDB_READ_TOKEN"),
 		MDBListAPIKey:         os.Getenv("XRDB_MDBLIST_API_KEY"),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -89,7 +90,9 @@ func Load() Config {
 	}
 	var cacheMaxBytes int64 = 256 << 20
 	if raw := os.Getenv("XRDB_CACHE_MAX_MB"); raw != "" {
-		if n, err := strconv.ParseInt(raw, 10, 64); err == nil && n > 0 {
+		// Bound before shifting: values above MaxInt64>>20 MiB would overflow
+		// the byte conversion and wrap the cap negative.
+		if n, err := strconv.ParseInt(raw, 10, 64); err == nil && n > 0 && n <= math.MaxInt64>>20 {
 			cacheMaxBytes = n << 20
 		}
 	}


### PR DESCRIPTION
The render cache could grow without bound and got more expensive to inspect as it grew. This bounds both tiers and makes stats cheap.

- Hot tier: byte cap (256 MiB) alongside the existing entry cap, LRU via container/list so hits are O(1) instead of a linear scan under the lock
- Disk tier: a background sweep every 10 minutes removes expired files and enforces 20k file / 2 GiB caps oldest-first; previously files were only deleted when their exact key was read again
- Stats: served from counters kept in step by writes and the sweep, replacing the per-call directory glob that admin stats polling multiplied

go build, go vet, and go test ./... pass (258 tests). The on-disk format is unchanged, so existing cache directories stay valid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable hot-cache limits for maximum entries and maximum total bytes (via environment variables).
  - Cache statistics now report hot-tier and disk-tier byte usage.
- **Bug Fixes**
  - Improved hot-cache eviction to enforce both entry and byte-based bounds.
  - Enhanced disk cache TTL handling with automatic background cleanup to prevent stale or excessive cache files.
- **Chores**
  - Improved cache lifecycle handling to ensure cache resources are properly released.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->