### PR TITLE
ci: build each Docker arch on its native runner

### DIFF
--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -36,7 +36,7 @@ jobs:
       image: ${{ steps.meta.outputs.image }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -82,6 +82,7 @@ jobs:
     needs: version
     permissions:
       contents: read
+      # Push per-architecture image digests to GHCR.
       packages: write
     strategy:
       matrix:
@@ -96,13 +97,13 @@ jobs:
             suffix: arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ needs.version.outputs.image }}
           labels: |
@@ -115,10 +116,10 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -126,7 +127,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: Dockerfile
@@ -144,7 +145,7 @@ jobs:
         run: echo "${{ steps.build.outputs.digest }}" > "/tmp/${{ matrix.suffix }}"
 
       - name: Upload digest artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: /tmp/${{ matrix.suffix }}
           archive: false
@@ -156,10 +157,11 @@ jobs:
     needs: [version, build]
     permissions:
       contents: read
+      # Publish the final tagged multi-arch manifest to GHCR.
       packages: write
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: /tmp/digests
           pattern: '{amd64,arm64}'
@@ -167,7 +169,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ needs.version.outputs.image }}
           flavor: |
@@ -179,10 +181,10 @@ jobs:
             type=sha,prefix=manual-,enable=${{ github.event_name == 'workflow_dispatch' && needs.version.outputs.publish_dev != 'true' }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -228,10 +230,11 @@ jobs:
     needs: [version, merge]
     if: ${{ github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch && needs.version.outputs.publish_dev == 'true' }}
     permissions:
+      # Push the discord-dev-notified checkpoint tag back to the repo.
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -6,6 +6,10 @@ run-name: >-
       || format('Docker publish {0}', github.ref_name)
   }}
 
+# Each architecture builds on its native runner (amd64 on ubuntu-latest,
+# arm64 on ubuntu-24.04-arm) instead of emulating arm64 through QEMU. Builds
+# push by digest only; the merge job stitches the digests into one tagged
+# multi-arch manifest.
 "on":
   push:
     branches:
@@ -29,6 +33,7 @@ jobs:
       dev_track_tag: ${{ steps.meta.outputs.dev_track_tag }}
       publish_dev: ${{ steps.meta.outputs.publish_dev }}
       publish_release_alias: ${{ steps.meta.outputs.publish_release_alias }}
+      image: ${{ steps.meta.outputs.image }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -68,24 +73,27 @@ jobs:
           echo "dev_track_tag=${dev_track_tag}" >> "$GITHUB_OUTPUT"
           echo "publish_dev=${publish_dev}" >> "$GITHUB_OUTPUT"
           echo "publish_release_alias=${publish_release_alias}" >> "$GITHUB_OUTPUT"
+          # ghcr image names must be lowercase.
+          echo "image=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
   build:
-    name: Build ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    name: Build (${{ matrix.suffix }})
+    runs-on: ${{ matrix.runner }}
     needs: version
     permissions:
-      contents: write
+      contents: read
       packages: write
     strategy:
       matrix:
+        # Single image: the web UI is statically exported and embedded in
+        # the Go binary (see Dockerfile stages).
         include:
-          # Single image: the web UI is statically exported and embedded in
-          # the Go binary (see Dockerfile stages).
-          - name: api
-            image: ghcr.io/${{ github.repository }}
-            context: .
-            dockerfile: Dockerfile
-
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            suffix: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            suffix: arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -96,14 +104,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ matrix.image }}
-          flavor: |
-            latest=false
-          tags: |
-            type=raw,value=${{ github.ref_name }},enable=${{ github.ref_type == 'tag' }}
-            type=raw,value=dev,enable=${{ needs.version.outputs.publish_dev == 'true' }}
-            type=raw,value=${{ needs.version.outputs.dev_track_tag }},enable=${{ needs.version.outputs.publish_dev == 'true' || needs.version.outputs.publish_release_alias == 'true' }}
-            type=sha,prefix=manual-,enable=${{ github.event_name == 'workflow_dispatch' && needs.version.outputs.publish_dev != 'true' }}
+          images: ${{ needs.version.outputs.image }}
           labels: |
             org.opencontainers.image.title=XRDB
             org.opencontainers.image.description=XRDB generates poster, backdrop, and logo images with ratings overlays on the fly.
@@ -112,9 +113,6 @@ jobs:
             org.opencontainers.image.documentation=${{ github.server_url }}/${{ github.repository }}#readme
             org.opencontainers.image.version=${{ needs.version.outputs.deployment_version }}
             org.opencontainers.image.revision=${{ github.sha }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -126,25 +124,108 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.platform }}
           push: true
           build-args: |
             XRDB_BUILD_VERSION=${{ needs.version.outputs.deployment_version }}
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           provenance: true
-          cache-from: type=gha,scope=${{ matrix.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+          outputs: type=image,name=${{ needs.version.outputs.image }},push-by-digest=true,name-canonical=true
+          cache-from: type=gha,scope=${{ matrix.suffix }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.suffix }}
+
+      - name: Export digest
+        run: echo "${{ steps.build.outputs.digest }}" > "/tmp/${{ matrix.suffix }}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v7
+        with:
+          path: /tmp/${{ matrix.suffix }}
+          archive: false
+          retention-days: 1
+
+  merge:
+    name: Merge manifests and tag
+    runs-on: ubuntu-latest
+    needs: [version, build]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v8
+        with:
+          path: /tmp/digests
+          pattern: '{amd64,arm64}'
+          merge-multiple: true
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ needs.version.outputs.image }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ github.ref_name }},enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=dev,enable=${{ needs.version.outputs.publish_dev == 'true' }}
+            type=raw,value=${{ needs.version.outputs.dev_track_tag }},enable=${{ needs.version.outputs.publish_dev == 'true' || needs.version.outputs.publish_release_alias == 'true' }}
+            type=sha,prefix=manual-,enable=${{ github.event_name == 'workflow_dispatch' && needs.version.outputs.publish_dev != 'true' }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest
+        env:
+          IMAGE: ${{ needs.version.outputs.image }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+
+          tag_args=()
+          while IFS= read -r tag; do
+            if [ -n "${tag}" ]; then
+              tag_args+=(-t "${tag}")
+            fi
+          done <<< "${TAGS}"
+
+          if [ "${#tag_args[@]}" -eq 0 ]; then
+            echo "No tags resolved for this run; refusing to push an untagged manifest." >&2
+            exit 1
+          fi
+
+          docker buildx imagetools create "${tag_args[@]}" \
+            "${IMAGE}@$(cat /tmp/digests/amd64)" \
+            "${IMAGE}@$(cat /tmp/digests/arm64)"
+
+      - name: Summary
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          {
+            echo "Pushed multi-arch manifest (linux/amd64, linux/arm64):"
+            echo '```'
+            echo "${TAGS}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   notify-dev:
     name: Notify Discord (dev build)
     runs-on: ubuntu-latest
-    needs: [version, build]
+    needs: [version, merge]
     if: ${{ github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch && needs.version.outputs.publish_dev == 'true' }}
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Docker publishes now build each architecture on its own native runner (amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm) and push by digest. A merge job stitches the two digests into one multi-arch manifest carrying the usual tags. This removes QEMU emulation from the arm64 half, which was the slow part of the single-job build, and gives each arch its own build cache scope.

Version metadata, image tags (including the dev track and release alias), labels, the XRDB_BUILD_VERSION build arg and the Discord dev notification all behave as before. The workflow name is unchanged, so create-github-release and promote-docker-latest still chain off it.

Validated by parsing the YAML and checking the tag matrix against each trigger path (version tag push, main push, manual dispatch). Same change as #52, adapted to this branch's version job and outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container release process to build native images for both amd64 and arm64, then publish a combined multi-architecture image.
  * Improved image naming consistency for published container releases.
  * Added clearer build output so release tags are easier to review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->