### PR TITLE
feat(provider): reach a source at a different base URL (XRDB_<SOURCE>_URL)

### DIFF
--- a/env.template
+++ b/env.template
@@ -204,6 +204,25 @@
 # everything; this overrides it for the named source. Credentials in the URL are
 # never logged.
 #XRDB_TMDB_PROXY=
+# Reach one source at a different base URL, named after the source:
+# XRDB_TMDB_URL, XRDB_MDBLIST_URL, XRDB_MDBLIST_ALT_URL, XRDB_TRAKT_URL,
+# XRDB_SIMKL_URL, XRDB_ANILIST_URL, XRDB_KITSU_URL, XRDB_FANART_MOVIES_URL,
+# XRDB_FANART_TV_URL, XRDB_CINEMETA_URL. (XRDB_JIKAN_URL already did this for
+# MAL and keeps its own name.)
+#
+# Different from the proxy above, and for a different problem. A proxy changes
+# the route to the source; the host in the URL stays the source's own. This
+# changes the host, for something in front of the source that mocks its API
+# surface and is addressed as though it were the source -- a caching
+# passthrough shared by several clients, so one lookup serves all of them, or
+# your own Jikan.
+#
+# The value is used exactly as given, and a trailing slash matters: some
+# sources build a request by concatenating a path onto the base rather than
+# resolving it. Copy the shape of the default you are replacing --
+# XRDB_KITSU_URL and the two fanart bases end in a slash, XRDB_TMDB_URL does
+# not.
+#XRDB_TMDB_URL=
 # Per-source request interval in seconds, named after the source:
 # XRDB_MAL_MIN_INTERVAL_SECONDS, XRDB_TRAKT_MIN_INTERVAL_SECONDS, and so on.
 # The interval protects the host a source talks to, so point MAL at your own

--- a/internal/provider/anilist.go
+++ b/internal/provider/anilist.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-const anilistGraphQLURL = "https://graphql.anilist.co"
+var anilistGraphQLURL = sourceBaseURL("ANILIST", "https://graphql.anilist.co")
 
 // AniList is the AniList.co GraphQL metadata provider (no auth required for public queries).
 // IDs must be prefixed with "al:" e.g. "al:21".

--- a/internal/provider/cinemeta.go
+++ b/internal/provider/cinemeta.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-const cinemetaBaseURL = "https://v3-cinemeta.strem.io"
+var cinemetaBaseURL = sourceBaseURL("CINEMETA", "https://v3-cinemeta.strem.io")
 const metahubImageBase = "https://images.metahub.space"
 
 // Cinemeta is the Stremio Cinemeta metadata/artwork provider.

--- a/internal/provider/fanart.go
+++ b/internal/provider/fanart.go
@@ -10,8 +10,8 @@ import (
 	"time"
 )
 
-const fanartMoviesURL = "https://webservice.fanart.tv/v3/movies/"
-const fanartTVURL = "https://webservice.fanart.tv/v3/tv/"
+var fanartMoviesURL = sourceBaseURL("FANART_MOVIES", "https://webservice.fanart.tv/v3/movies/")
+var fanartTVURL = sourceBaseURL("FANART_TV", "https://webservice.fanart.tv/v3/tv/")
 
 // Fanart is the Fanart.tv metadata provider.
 // It returns high-quality logos, posters, and art images.

--- a/internal/provider/kitsu.go
+++ b/internal/provider/kitsu.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-const kitsuBaseURL = "https://kitsu.io/api/edge/anime/"
+var kitsuBaseURL = sourceBaseURL("KITSU", "https://kitsu.io/api/edge/anime/")
 
 // Kitsu is the Kitsu.io metadata provider (no auth required for public queries).
 // IDs must be prefixed with "kitsu:" e.g. "kitsu:7442".

--- a/internal/provider/mdblist.go
+++ b/internal/provider/mdblist.go
@@ -16,12 +16,12 @@ import (
 	"xrdb_rewrite/internal/logging"
 )
 
-const mdblistBase = "https://api.mdblist.com"
+var mdblistBase = sourceBaseURL("MDBLIST", "https://api.mdblist.com")
 
 // mdblistAltBase is MDBList's other host for the same data. It answers movies
 // and shows from one call, reports a missing title as a 200 with response
 // false, and carries no awards field.
-const mdblistAltBase = "https://mdblist.com/api"
+var mdblistAltBase = sourceBaseURL("MDBLIST_ALT", "https://mdblist.com/api")
 
 // errHostUnreachable marks a failure of api.mdblist.com itself rather than of
 // the request or the key. Only these are worth retrying on the other host: a

--- a/internal/provider/simkl.go
+++ b/internal/provider/simkl.go
@@ -16,7 +16,7 @@ import (
 
 var simklNumericIDRe = regexp.MustCompile(`^\d+$`)
 
-const simklBaseURL = "https://api.simkl.com"
+var simklBaseURL = sourceBaseURL("SIMKL", "https://api.simkl.com")
 
 var simklIMDbIDRe = regexp.MustCompile(`^tt\d+$`)
 

--- a/internal/provider/sourceurl.go
+++ b/internal/provider/sourceurl.go
@@ -1,0 +1,33 @@
+package provider
+
+import (
+	"os"
+	"strings"
+)
+
+// sourceBaseURL returns the base URL a source is reached at: XRDB_<NAME>_URL
+// when that is set and non-empty, the compiled-in default otherwise.
+//
+// This is deliberately a different mechanism from XRDB_<SOURCE>_PROXY. A proxy
+// is the answer when the upstream is blocked or throttled by address: the
+// request still goes to the upstream's own host, just by a different route. A
+// base URL is the answer when something in front of the upstream *mocks its API
+// surface* and is addressed as though it were the upstream -- a caching
+// passthrough shared by several clients, so that one lookup serves all of them.
+// A proxy setting cannot express that, because the host in the URL never
+// changes.
+//
+// XRDB_JIKAN_URL already does exactly this for MAL, for the same reason: "what
+// upstream pays for is a favour rather than a dependency". This generalises it
+// to every source that has a single base.
+//
+// The value is used exactly as given. A trailing slash is significant, because
+// several sources build a request by concatenating a path onto the base rather
+// than resolving it as a URL reference -- kitsuBaseURL and the fanart bases end
+// in one, tmdbBaseURL does not. Copy the shape of the default being replaced.
+func sourceBaseURL(name, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv("XRDB_" + name + "_URL")); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/internal/provider/sourceurl_test.go
+++ b/internal/provider/sourceurl_test.go
@@ -1,0 +1,31 @@
+package provider
+
+import "testing"
+
+func TestSourceBaseURL(t *testing.T) {
+	const def = "https://api.example.invalid/3"
+
+	if got := sourceBaseURL("NOT_SET_ANYWHERE", def); got != def {
+		t.Errorf("an unset variable should fall back to the default, got %q", got)
+	}
+
+	t.Setenv("XRDB_TESTSOURCE_URL", "http://cache.internal/tmdb/3")
+	if got := sourceBaseURL("TESTSOURCE", "https://api.themoviedb.org/3"); got != "http://cache.internal/tmdb/3" {
+		t.Errorf("the override was ignored, got %q", got)
+	}
+
+	// A trailing slash is significant: kitsuBaseURL and the fanart bases are
+	// concatenated with a path rather than resolved as a URL reference, so
+	// losing the slash silently mangles every request built from them.
+	t.Setenv("XRDB_TESTSOURCE_URL", "http://cache.internal/kitsu/api/edge/anime/")
+	if got := sourceBaseURL("TESTSOURCE", "https://kitsu.io/api/edge/anime/"); got != "http://cache.internal/kitsu/api/edge/anime/" {
+		t.Errorf("the trailing slash was lost, got %q", got)
+	}
+
+	// Whitespace-only is treated as unset rather than as an empty base, which
+	// would otherwise turn every request into a relative path.
+	t.Setenv("XRDB_TESTSOURCE_URL", "   ")
+	if got := sourceBaseURL("TESTSOURCE", def); got != def {
+		t.Errorf("a whitespace-only value should fall back to the default, got %q", got)
+	}
+}

--- a/internal/provider/tmdb.go
+++ b/internal/provider/tmdb.go
@@ -19,7 +19,7 @@ import (
 	"xrdb_rewrite/internal/logging"
 )
 
-const tmdbBaseURL = "https://api.themoviedb.org/3"
+var tmdbBaseURL = sourceBaseURL("TMDB", "https://api.themoviedb.org/3")
 const tmdbImageBase = "https://image.tmdb.org/t/p"
 
 // TMDB is the TMDB metadata provider.

--- a/internal/provider/trakt.go
+++ b/internal/provider/trakt.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-const traktBaseURL = "https://api.trakt.tv"
+var traktBaseURL = sourceBaseURL("TRAKT", "https://api.trakt.tv")
 
 var traktIMDbIDRe = regexp.MustCompile(`^tt\d+$`)
 


### PR DESCRIPTION
Hi! ElfHosted runs the public instance you invited us to host, and this is the first of two changes that came out of that. Both are meant to be generally useful rather than specific to us — happy to adjust or drop either if you'd rather they went a different way.

## What this does

`XRDB_JIKAN_URL` already lets an operator point MAL at their own Jikan, for the reason `mal.go` gives: *"what upstream pays for is a favour rather than a dependency"*. That argument applies to every other source too, and there's currently no way to act on it.

This generalises that one setting into `XRDB_<SOURCE>_URL`, covering TMDB, MDBList (and its alternate base), Trakt, SIMKL, AniList, Kitsu, both fanart bases and Cinemeta. `XRDB_JIKAN_URL` keeps its own name.

## Why not `XRDB_<SOURCE>_PROXY`

That already exists and solves a different problem. A proxy changes the *route* to a source while the host in the URL stays the source's own — right when a source blocks or throttles by address. This changes the *host*, for something in front of the source that mocks its API surface and is addressed as though it were the source: a caching passthrough shared by several clients so one lookup serves all of them, or a self-hosted copy of the source. A proxy setting can't express that, because the hostname never changes.

For us it means the metered lookups from several replicas collapse onto one shared cache, so we're a much lighter client of TMDB, MDBList, Trakt and the rest than the replica count suggests.

## Shape

Each base becomes a package-level `var` reading the environment once via `sourceBaseURL`. A source that isn't overridden costs nothing and behaves exactly as before — one line changed per provider.

## One trap, documented in both the code and env.template

**A trailing slash is significant.** Several sources build a request by concatenating a path onto the base rather than resolving it as a URL reference, so `kitsuBaseURL` and the two fanart bases end in a slash while `tmdbBaseURL` doesn't. The value is used exactly as given, and the guidance is to copy the shape of the default being replaced. Getting this wrong mangles every request from that source, so it seemed worth calling out twice.

## Testing

`internal/provider/sourceurl_test.go` covers fallback when unset, the override, trailing-slash preservation, and whitespace-only treated as unset. Full `./internal/provider/` and `./internal/config/` suites pass, including `TestEveryEnvVarIsInTheTemplate`.

Running in production on our public instance since deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable base URL overrides for supported content sources through environment settings.
  - Added overrides for TMDB, MDBList, Trakt, Simkl, AniList, Kitsu, Fanart, and Cinemeta.
  - Source URLs retain their configured format, including significant trailing slashes.
  - Existing default source addresses remain available when no override is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->