### PR TITLE
fix(web): point six rating logos at the files that actually ship

### DIFF
--- a/web/components/configurator-types.ts
+++ b/web/components/configurator-types.ts
@@ -126,22 +126,22 @@ export const TREND_STYLE_OPTIONS = [
 ] as const;
 
 export const RATING_OPTIONS: { id: string; label: string; accent: string; icon: string; group?: string }[] = [
-  { id: 'imdb',           label: 'IMDb',            accent: '#f5c518', icon: '/rating-logos/imdb.svg' },
+  { id: 'imdb',           label: 'IMDb',            accent: '#f5c518', icon: '/rating-logos/imdb.png' },
   { id: 'tmdb',           label: 'TMDB',            accent: '#01b4e4', icon: '/rating-logos/tmdb.svg' },
   { id: 'rt',             label: 'RT Critics',      accent: '#fa320a', icon: '/rating-logos/rt.svg' },
   { id: 'rtaudience',     label: 'RT Audience',     accent: '#fa320a', icon: '/rating-logos/rtaudience.svg' },
-  { id: 'metacritic',     label: 'Metacritic',      accent: '#ffcc34', icon: '/rating-logos/metacritic.svg' },
+  { id: 'metacritic',     label: 'Metacritic',      accent: '#ffcc34', icon: '/rating-logos/metacritic.png' },
   { id: 'metacriticuser', label: 'Metacritic User', accent: '#ffcc34', icon: '/rating-logos/metacriticuser.svg' },
-  { id: 'letterboxd',     label: 'Letterboxd',      accent: '#00a99d', icon: '/rating-logos/letterboxd.svg' },
-  { id: 'mdblist',        label: 'MDBList',         accent: '#8b5cf6', icon: '/rating-logos/mdblist.svg' },
+  { id: 'letterboxd',     label: 'Letterboxd',      accent: '#00a99d', icon: '/rating-logos/letterboxd.png' },
+  { id: 'mdblist',        label: 'MDBList',         accent: '#8b5cf6', icon: '/rating-logos/mdblist.png' },
   { id: 'trakt',          label: 'Trakt',           accent: '#ed1c24', icon: '/rating-logos/trakt.svg' },
   { id: 'simkl',          label: 'SIMKL',           accent: '#1cb0f6', icon: '/rating-logos/simkl.svg' },
   { id: 'rogerebert',     label: 'Roger Ebert',     accent: '#c1121f', icon: '/rating-logos/rogerebert.png' },
   { id: 'allocine',       label: 'AlloCiné',        accent: '#fecc00', icon: '/rating-logos/allocine.svg' },
   { id: 'allocinepress',  label: 'AlloCiné Press',  accent: '#f59e0b', icon: '/rating-logos/allocinepress.svg' },
   { id: 'filmweb',        label: 'Filmweb',         accent: '#ecb014', icon: '/rating-logos/filmweb.png' },
-  { id: 'mal',            label: 'MyAnimeList',     accent: '#2c6fbb', icon: '/rating-logos/mal.svg', group: 'anime' },
-  { id: 'anilist',        label: 'AniList',         accent: '#02a9ff', icon: '/rating-logos/anilist.svg', group: 'anime' },
+  { id: 'mal',            label: 'MyAnimeList',     accent: '#2c6fbb', icon: '/rating-logos/mal.png', group: 'anime' },
+  { id: 'anilist',        label: 'AniList',         accent: '#02a9ff', icon: '/rating-logos/anilist.png', group: 'anime' },
   { id: 'kitsu',          label: 'Kitsu',           accent: '#f76e18', icon: '/rating-logos/kitsu.svg', group: 'anime' },
 ];
 

--- a/web/components/site-footer.tsx
+++ b/web/components/site-footer.tsx
@@ -39,7 +39,7 @@ export function SiteFooter() {
             title="IMDb"
           >
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src="/rating-logos/imdb.svg" alt="IMDb" width={32} height={32} />
+            <img src="/rating-logos/imdb.png" alt="IMDb" width={32} height={32} />
           </a>
           <p>
             Information courtesy of{' '}


### PR DESCRIPTION
Third one, and this is a plain bug rather than a feature — found in the access log of the public instance, from real browsers.

Six icons are referenced as `.svg` but ship as `.png`, so the configurator's rating picker renders a broken image for IMDb, MDBList, Metacritic, MyAnimeList, Letterboxd and AniList. The footer shows one for IMDb too.

```
/rating-logos/imdb.svg        404      imdb.png        200
/rating-logos/mdblist.svg     404      mdblist.png     200
/rating-logos/metacritic.svg  404      metacritic.png  200
/rating-logos/mal.svg         404      mal.png         200
/rating-logos/letterboxd.svg  404      letterboxd.png  200
/rating-logos/anilist.svg     404      anilist.png     200
```

The other eleven references are correct, which is probably why it survived: the picker is mostly fine, and a missing icon reads as a slow load rather than a 404 unless you're looking at server logs.

IMDb is the one that stings — it's the most-wanted rating and its icon is broken in both the picker and the footer.

## Verification

Every `/rating-logos/` reference under `web/` now resolves to a file in `web/public/rating-logos/`:

```python
files = {p.name for p in Path('web/public/rating-logos').iterdir()}
# every /rating-logos/X reference in web/**/*.{ts,tsx} is now in `files`
```

Before: 17 referenced, 6 broken. After: 0 broken.

I've left the images themselves alone — swapping the PNGs for real SVGs would be a nicer fix but it's your call on artwork, and this is the one-line-per-icon version that stops the 404s today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated rating and IMDb attribution logos to use PNG image assets.
  * Preserved existing logo dimensions, labels, and supported rating sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->